### PR TITLE
simple warning for the 128 char limit in filenames incl. paths

### DIFF
--- a/bin/xbps-create/main.c
+++ b/bin/xbps-create/main.c
@@ -319,6 +319,11 @@ ftw_cb(const char *fpath, const struct stat *sb, int type, struct FTW *ftwbuf _u
 	 * use the keysym, as this value has the unsanatized path.
 	 */
 	xbps_dictionary_set_cstring(fileinfo, "file", filep);
+
+	/* Warning due to 128 char limit in file paths */
+	if (strlen(filep) >= 128)
+	  printf("! Warning not included (128char bug): %s\n", filep);
+
 	xbps_dictionary_set(all_filesd, fpath, fileinfo);
 
 	if ((strcmp(fpath, "./INSTALL") == 0) ||


### PR DESCRIPTION
I think it is crucial to  be aware of the problem with 128 char limits in the current implementation of xbps-create, as described in issue https://github.com/void-linux/xbps/issues/2.

Extending the portableproplib to accept keys with more than 128 characters is not trivial as I found out today, neither is fixing the current xbps-create implementation.

Until we have fixed this I think it is important to keep an eye on what is not getting packed into a package with xbps. This could have quite some stability implications for void-linux and currently nobody knows how much is not getting packed when using xbps-create.

Utilizing the test from @abenson in issue https://github.com/void-linux/xbps/issues/2 results now in a warning message:
`! Warning not included (128char bug): /b1/b2/b3/b4/b5/b6/b7/b8/b9/b10/b11/b12/b13/b14/b15/b16/b17/b18/b19/b20/b21/b22/b23/b24/b25/b26/b27/b28/b29/b30/b31/b32/b33/bbbb`
and as he demonstrated, the bbbb file does not get packed into the xbps package with the current version of xbps-create.

Hope this helps until we fix the issue