### PR TITLE
Fix string formatting of 64-bit unsigned integers

### DIFF
--- a/bin/xbps-create/main.c
+++ b/bin/xbps-create/main.c
@@ -426,7 +426,7 @@ ftw_cb(const char *fpath, const struct stat *sb, const struct dirent *dir _unuse
 		TAILQ_FOREACH(xep, &xentry_list, entries) {
 			if (sb->st_nlink > 1 && xep->inode == sb->st_ino) {
 				/* matched */
-				printf("%lu %lu\n", xep->inode, sb->st_ino);
+				printf("%"PRIu64" %"PRIu64"\n", xep->inode, sb->st_ino);
 				hlink = true;
 				break;
 			}
@@ -441,7 +441,7 @@ ftw_cb(const char *fpath, const struct stat *sb, const struct dirent *dir _unuse
 			xbps_dictionary_get_uint64(linkinfo, "inode", &inode);
 			if (inode == sb->st_ino) {
 				/* matched */
-				printf("%lu %lu\n", inode, sb->st_ino);
+				printf("%"PRIu64" %"PRIu64"\n", inode, sb->st_ino);
 				break;
 			}
 		}

--- a/lib/package_unpack.c
+++ b/lib/package_unpack.c
@@ -377,13 +377,13 @@ unpack_archive(struct xbps_handle *xhp,
 			    archive_entry_gid(entry)) != 0) {
 				xbps_dbg_printf(xhp,
 				    "%s: failed "
-				    "to set uid/gid to %zu:%zu (%s)\n",
+				    "to set uid/gid to %"PRIu64":%"PRIu64" (%s)\n",
 				    pkgver, archive_entry_uid(entry),
 				    archive_entry_gid(entry),
 				    strerror(errno));
 			} else {
 				xbps_dbg_printf(xhp, "%s: entry %s changed "
-				    "uid/gid to %zu:%zu.\n", pkgver, entry_pname,
+				    "uid/gid to %"PRIu64":%"PRIu64".\n", pkgver, entry_pname,
 				    archive_entry_uid(entry),
 				    archive_entry_gid(entry));
 			}
@@ -426,7 +426,7 @@ unpack_archive(struct xbps_handle *xhp,
 				      AT_SYMLINK_NOFOLLOW) == -1) {
 				xbps_dbg_printf(xhp,
 				    "%s: failed "
-				    "to set mtime %ju to %s: %s\n",
+				    "to set mtime %lu to %s: %s\n",
 				    pkgver, archive_entry_mtime_nsec(entry),
 				    entry_pname,
 				    strerror(errno));


### PR DESCRIPTION
Fixes building on 32-bit systems (prior to GCC 7.x?)

Based on patch by @pbui from the previous repository: voidlinux/xbps#287
