### PR TITLE
lib/package_unpack.c: remove files of wrong filetype in path

### DIFF
--- a/tests/xbps/xbps-install/behaviour_tests.sh
+++ b/tests/xbps/xbps-install/behaviour_tests.sh
@@ -58,8 +58,36 @@ update_existent_body() {
 	atf_check_equal $? 0
 }
 
+update_extract_dir_head() {
+	atf_set "descr" "xbps-install(8): update and change file type"
+}
+
+update_extract_dir_body() {
+	mkdir -p some_repo pkg_A
+	touch pkg_A/file00
+	cd some_repo
+	xbps-create -A noarch -n A-1.0_1 -s "A pkg" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+	xbps-install -r root -C empty.conf --repository=$PWD/some_repo -y A
+	atf_check_equal $? 0
+	rm pkg_A/file00
+	mkdir -p pkg_A/file00
+	touch pkg_A/file00/file01
+	cd some_repo
+	xbps-create -A noarch -n A-1.1_1 -s "A pkg" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+	xbps-install -r root -C empty.conf --repository=$PWD/some_repo -d -Suy A
+	atf_check_equal $? 0
+}
 
 atf_init_test_cases() {
 	atf_add_test_case install_existent
 	atf_add_test_case update_existent
+	atf_add_test_case update_extract_dir
 }


### PR DESCRIPTION
This change removes regular files which prevent extracting directories with the same name. Fixes #14.

I only tested it with updating gimp to version 2.10.6_1.

It doesn't fix the other way round where a regular files has to be extracted over a non-empty directory (this fails with `[unpack] failed to extract files: Directory not empty`).