### PR TITLE
lib/package_remove: reverse order of file removal

### DIFF
--- a/lib/package_remove.c
+++ b/lib/package_remove.c
@@ -100,7 +100,6 @@ remove_pkg_files(struct xbps_handle *xhp,
 		 const char *pkgver)
 {
 	xbps_array_t array;
-	xbps_object_iterator_t iter;
 	xbps_object_t obj;
 	const char *curobj = NULL;
 	/* These are symlinks in Void and must not be removed */
@@ -124,10 +123,6 @@ remove_pkg_files(struct xbps_handle *xhp,
 	if (xbps_array_count(array) == 0)
 		return 0;
 
-	iter = xbps_array_iter_from_dict(dict, key);
-	if (iter == NULL)
-		return ENOMEM;
-
 	if (strcmp(key, "files") == 0)
 		curobj = "file";
 	else if (strcmp(key, "conf_files") == 0)
@@ -137,13 +132,12 @@ remove_pkg_files(struct xbps_handle *xhp,
 	else if (strcmp(key, "dirs") == 0)
 		curobj = "directory";
 
-	xbps_object_iterator_reset(iter);
-
-	while ((obj = xbps_object_iterator_next(iter))) {
+	for (unsigned int j = xbps_array_count(array) - 1; j > 0; --j) {
 		const char *file, *sha256;
 		char path[PATH_MAX];
 		bool found;
 
+		obj = xbps_array_get(array, j);
 		xbps_dictionary_get_cstring_nocopy(obj, "file", &file);
 		snprintf(path, sizeof(path), "%s/%s", xhp->rootdir, file);
 
@@ -246,7 +240,6 @@ remove_pkg_files(struct xbps_handle *xhp,
 			    0, pkgver, "Removed %s `%s'", curobj, file);
 		}
 	}
-	xbps_object_iterator_release(iter);
 
 	return rv;
 }


### PR DESCRIPTION
`xbps-remove` fails to remove some directories, see https://github.com/void-linux/xbps/issues/23.
This happens because they are removed in the wrong order, e.g. for a package with the files `a` and `a/b`, `remove(3)` is first called on `a` where it fails and then on `a/b`.

Reversing the order of the files to be removed fixes this.