### PR TITLE
travis: downgrade libarchive and fix travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ compiler:
 
 addons:
   apt:
-    sources:
+    packages:
         - gdb
         - liblua5.2-0
         - liblua5.2-dev
@@ -16,10 +16,10 @@ addons:
         - libssl-dev
         - libarchive-dev
 env:
-        - PKG_CONFIG_PATH=/tmp/usr/lib/pkgconfig LD_LIBRARY_PATH=/tmp/usr/lib
+        - PATH=$PATH:/tmp/usr/bin PKG_CONFIG_PATH=/tmp/usr/lib/pkgconfig LD_LIBRARY_PATH=/tmp/usr/lib
 
 before_install:
         - ./admin/travis-install-deps.sh
 
 script:
-        - LDFLAGS="-L/tmp/usr/lib -Wl,-R/tmp/usr/lib" ./configure --enable-tests --enable-debug && make -j16 && make check
+        - CFLAGS="-I/tmp/usr/include" LDFLAGS="-L/tmp/usr/lib -Wl,-R/tmp/usr/lib" ./configure --enable-tests --enable-debug && make -j16 && make check

--- a/admin/travis-install-deps.sh
+++ b/admin/travis-install-deps.sh
@@ -47,9 +47,9 @@ install_from_github() {
         --disable-developer \
         --without-atf \
         --without-doxygen \
-        CPPFLAGS="-I/usr/local/include" \
-        LDFLAGS="-L/usr/local/lib -Wl,-R/usr/local/lib" \
-        PKG_CONFIG_PATH="/usr/local/lib/pkgconfig"
+        CPPFLAGS="-I/tmp/usr/include" \
+        LDFLAGS="-L/tmp/usr/lib -Wl,-R/tmp/usr/lib" \
+        PKG_CONFIG_PATH="/tmp/usr/lib/pkgconfig"
     make -j16
     make install
     cd -

--- a/configure
+++ b/configure
@@ -660,7 +660,7 @@ fi
 #
 # libarchive with pkg-config support is required.
 #
-LIBARCHIVE_REQVER=3.2.0
+LIBARCHIVE_REQVER=3.1.2
 
 printf "Checking for libarchive >= ${LIBARCHIVE_REQVER}  via pkg-config ... "
 if ! $PKGCONFIG_BIN --atleast-version=${LIBARCHIVE_REQVER} libarchive; then


### PR DESCRIPTION
I wanted to fix travis. Ubuntu only has libarchive up to 3.1.2. I'm not sure if there is anything that strongly depends on >=3.2.0, but all the tests pass now. I suppose the only other option would be to compile a newer version on travis. There was a long gap between 3.1.2 and 3.2.x, and looks like they found some security bugs, but in practice xbps will be built on void and with 3.3.x anyway. I can build a newer version from source if that is desired, though.

I also had to slightly change some of the travis scripts to get all the dependencies to compile and work.