### PR TITLE
import gcc8 patches from xbps-src

### DIFF
--- a/bin/xbps-checkvers/main.c
+++ b/bin/xbps-checkvers/main.c
@@ -599,9 +599,9 @@ rcv_check_version(rcv_t *rcv)
 	else
 		rcv->pkgd = xbps_rpool_get_pkg(&rcv->xhp, srcver);
 
-	srcver = strncat(srcver, "-", 1);
+	srcver = strncat(srcver, "-", 2);
 	srcver = strncat(srcver, version.v.s, version.v.len);
-	srcver = strncat(srcver, "_", 1);
+	srcver = strncat(srcver, "_", 2);
 	srcver = strncat(srcver, revision.v.s, revision.v.len);
 
 	xbps_dictionary_get_cstring_nocopy(rcv->pkgd, "pkgver", &repover);

--- a/lib/initend.c
+++ b/lib/initend.c
@@ -398,6 +398,7 @@ xbps_init(struct xbps_handle *xhp)
 {
 	struct utsname un;
 	char cwd[PATH_MAX-1], sysconfdir[XBPS_MAXPATH+sizeof(XBPS_SYSDEFCONF_PATH)], *buf;
+	char relpath[PATH_MAX+1+XBPS_MAXPATH];
 	const char *repodir, *native_arch;
 	int rv;
 
@@ -412,9 +413,13 @@ xbps_init(struct xbps_handle *xhp)
 		xhp->rootdir[0] = '/';
 		xhp->rootdir[1] = '\0';
 	} else if (xhp->rootdir[0] != '/') {
+		size_t len;
 		buf = strdup(xhp->rootdir);
-		snprintf(xhp->rootdir, sizeof(xhp->rootdir), "%s/%s", cwd, buf);
+		len = snprintf(relpath, sizeof(relpath), "%s/%s", cwd, buf);
 		free(buf);
+		if (len >= XBPS_MAXPATH)
+			return ENOTSUP;
+		memcpy(xhp->rootdir, relpath, len + 1);
 	}
 	xbps_dbg_printf(xhp, "%s\n", XBPS_RELVER);
 	/* set confdir */

--- a/tests/xbps/libxbps/config/main.c
+++ b/tests/xbps/libxbps/config/main.c
@@ -39,6 +39,8 @@ ATF_TC_BODY(config_include_test, tc)
 	struct xbps_handle xh;
 	const char *tcsdir;
 	char *buf, *buf2, pwd[PATH_MAX];
+	char confdir[PATH_MAX + 1 + sizeof("xbps.d")];
+	size_t len;
 
 	/* get test source dir */
 	tcsdir = atf_tc_get_config_var(tc, "srcdir");
@@ -48,7 +50,9 @@ ATF_TC_BODY(config_include_test, tc)
 
 	xbps_strlcpy(xh.rootdir, pwd, sizeof(xh.rootdir));
 	xbps_strlcpy(xh.metadir, pwd, sizeof(xh.metadir));
-	snprintf(xh.confdir, sizeof(xh.confdir), "%s/xbps.d", pwd);
+	len = snprintf(confdir, sizeof(confdir), "%s/xbps.d", pwd);
+	ATF_REQUIRE_EQ((len < sizeof(xh.confdir)), 1);
+	memcpy(xh.confdir, confdir, len + 1);
 
 	ATF_REQUIRE_EQ(xbps_mkpath(xh.confdir, 0755), 0);
 
@@ -88,6 +92,8 @@ ATF_TC_BODY(config_include_nomatch_test, tc)
 	struct xbps_handle xh;
 	const char *tcsdir;
 	char *buf, *buf2, pwd[PATH_MAX];
+	char confdir[PATH_MAX + 1 + sizeof("xbps.d")];
+	size_t len;
 
 	/* get test source dir */
 	tcsdir = atf_tc_get_config_var(tc, "srcdir");
@@ -97,7 +103,9 @@ ATF_TC_BODY(config_include_nomatch_test, tc)
 
 	xbps_strlcpy(xh.rootdir, tcsdir, sizeof(xh.rootdir));
 	xbps_strlcpy(xh.metadir, tcsdir, sizeof(xh.metadir));
-	snprintf(xh.confdir, sizeof(xh.confdir), "%s/xbps.d", pwd);
+	len = snprintf(confdir, sizeof(confdir), "%s/xbps.d", pwd);
+	ATF_REQUIRE_EQ((len < sizeof(xh.confdir)), 1);
+	memcpy(xh.confdir, confdir, len + 1);
 
 	ATF_REQUIRE_EQ(xbps_mkpath(xh.confdir, 0755), 0);
 


### PR DESCRIPTION
These patches allow xbps to compile under gcc8. just pulled from void-packages.