### PR TITLE
xbps.d.5: fix referenced sections

### DIFF
--- a/data/xbps.d.5
+++ b/data/xbps.d.5
@@ -134,16 +134,16 @@ Default package database (0.38 format). Keeps track of installed packages and pr
 Default cache directory to store downloaded binary packages.
 .El
 .Sh SEE ALSO
-.Xr xbps-checkvers 8 ,
-.Xr xbps-create 8 ,
-.Xr xbps-dgraph 8 ,
-.Xr xbps-install 8 ,
-.Xr xbps-pkgdb 8 ,
-.Xr xbps-query 8 ,
-.Xr xbps-reconfigure 8 ,
-.Xr xbps-remove 8 ,
-.Xr xbps-rindex 8 ,
-.Xr xbps-uchroot 8
+.Xr xbps-checkvers 1 ,
+.Xr xbps-create 1 ,
+.Xr xbps-dgraph 1 ,
+.Xr xbps-install 1 ,
+.Xr xbps-pkgdb 1 ,
+.Xr xbps-query 1 ,
+.Xr xbps-reconfigure 1 ,
+.Xr xbps-remove 1 ,
+.Xr xbps-rindex 1 ,
+.Xr xbps-uchroot 1
 .Sh AUTHORS
 .An Juan Romero Pardines <xtraeme@gmail.com>
 .Sh BUGS


### PR DESCRIPTION
the utilities were moved to user commands in fcdd71aac4d9278d89cd13ec226b4e27e488f42e but this file wasn't changed