### PR TITLE
fix setting alternatives groups for packages that have more than one

### DIFF
--- a/lib/package_alternatives.c
+++ b/lib/package_alternatives.c
@@ -249,6 +249,9 @@ xbps_alternatives_set(struct xbps_handle *xhp, const char *pkgname,
 	if (!xbps_dictionary_count(pkg_alternatives))
 		return ENOENT;
 
+	if (group && !xbps_dictionary_get(pkg_alternatives, group))
+		return ENOENT;
+
 	xbps_dictionary_get_cstring_nocopy(pkgd, "pkgver", &pkgver);
 
 	allkeys = xbps_dictionary_all_keys(pkg_alternatives);
@@ -261,10 +264,8 @@ xbps_alternatives_set(struct xbps_handle *xhp, const char *pkgname,
 		keysym = xbps_array_get(allkeys, i);
 		keyname = xbps_dictionary_keysym_cstring_nocopy(keysym);
 
-		if (group && strcmp(keyname, group)) {
-			rv = ENOENT;
+		if (group && strcmp(keyname, group))
 			continue;
-		}
 
 		array = xbps_dictionary_get(alternatives, keyname);
 		if (array == NULL)
@@ -294,7 +295,7 @@ xbps_alternatives_set(struct xbps_handle *xhp, const char *pkgname,
 		xbps_set_cb_state(xhp, XBPS_STATE_ALTGROUP_ADDED, 0, NULL,
 		    "%s: applying '%s' alternatives group", pkgver, keyname);
 		rv = create_symlinks(xhp, xbps_dictionary_get(pkg_alternatives, keyname), keyname);
-		if (rv != 0)
+		if (rv != 0 || group)
 			break;
 	}
 	xbps_object_release(allkeys);

--- a/tests/xbps/xbps-alternatives/main.sh
+++ b/tests/xbps/xbps-alternatives/main.sh
@@ -348,6 +348,8 @@ set_pkg_group_body() {
 
 	xbps-install -r root --repository=repo -ydv A B
 	atf_check_equal $? 0
+	xbps-alternatives -r root -s A -g 1
+	atf_check_equal $? 0
 	xbps-alternatives -r root -s B -g 2
 	atf_check_equal $? 0
 


### PR DESCRIPTION
the `group && strcmp(keyname, group)` check in the loop would make the function always return `ENOENT` when setting an alternatives group that wasn't the only/last one in the dictionary

`xbps-alternatives` checks the return value of `xbps_alternatives_set` and doesn't update the pkgdb on failure (even if it updated the symlinks)

you can test it with `xbps-alternatives -g hostname -s busybox` and `xbps-alternatives -g hostname -l` (assuming you have hostname from another package)