### PR TITLE
Maybe we need upgrade to openssl 1.1.x.

### DIFF
--- a/configure
+++ b/configure
@@ -678,7 +678,7 @@ fi
 # libssl with pkg-config support is required.
 #
 printf "Checking for libssl via pkg-config ... "
-if $PKGCONFIG_BIN --exists 'libssl < 1.1' && ! $PKGCONFIG_BIN --exists libtls ; then
+if $PKGCONFIG_BIN --exists 'libssl < 1.2' && ! $PKGCONFIG_BIN --exists libtls ; then
 	echo "found OpenSSL version $($PKGCONFIG_BIN --modversion libssl)."
 elif $PKGCONFIG_BIN --exists libssl libtls; then
 	echo "found LibreSSL version $($PKGCONFIG_BIN --modversion libssl)."

--- a/lib/fetch/common.c
+++ b/lib/fetch/common.c
@@ -895,7 +895,7 @@ fetch_ssl_verify_altname(STACK_OF(GENERAL_NAME) *altnames,
 
 	for (i = 0; i < sk_GENERAL_NAME_num(altnames); ++i) {
 		name = sk_GENERAL_NAME_value(altnames, i);
-		ns = (const char *)ASN1_STRING_data(name->d.ia5);
+		ns = (const char *)ASN1_STRING_get0_data(name->d.ia5);
 		nslen = (size_t)ASN1_STRING_length(name->d.ia5);
 
 		if (name->type == GEN_DNS && ip == NULL &&

--- a/lib/pubkey2fp.c
+++ b/lib/pubkey2fp.c
@@ -65,12 +65,13 @@ fp2str(unsigned const char *fp, unsigned int len)
 char *
 xbps_pubkey2fp(struct xbps_handle *xhp, xbps_data_t pubkey)
 {
-	EVP_MD_CTX mdctx;
+	EVP_MD_CTX *mdctx = NULL;
 	EVP_PKEY *pPubKey = NULL;
 	RSA *pRsa = NULL;
 	BIO *bio = NULL;
 	const void *pubkeydata;
 	unsigned char md_value[EVP_MAX_MD_SIZE];
+	const BIGNUM *n, *e;
 	unsigned char *nBytes = NULL, *eBytes = NULL, *pEncoding = NULL;
 	unsigned int md_len = 0;
 	char *hexfpstr = NULL;
@@ -79,6 +80,8 @@ xbps_pubkey2fp(struct xbps_handle *xhp, xbps_data_t pubkey)
 	ERR_load_crypto_strings();
 	OpenSSL_add_all_algorithms();
 
+	mdctx = EVP_MD_CTX_new();
+	assert(mdctx);
 	pubkeydata = xbps_data_data_nocopy(pubkey);
 	bio = BIO_new_mem_buf(__UNCONST(pubkeydata), xbps_data_size(pubkey));
 	assert(bio);
@@ -91,7 +94,7 @@ xbps_pubkey2fp(struct xbps_handle *xhp, xbps_data_t pubkey)
 		goto out;
 	}
 
-	if (EVP_PKEY_type(pPubKey->type) != EVP_PKEY_RSA) {
+	if (EVP_PKEY_base_id(pPubKey) != EVP_PKEY_RSA) {
 		xbps_dbg_printf(xhp, "only RSA public keys are currently supported\n");
 		goto out;
 	}
@@ -103,19 +106,20 @@ xbps_pubkey2fp(struct xbps_handle *xhp, xbps_data_t pubkey)
 		goto out;
 	}
 
+	RSA_get0_key(pRsa, &n, &e, NULL);
 	// reading the modulus
-	nLen = BN_num_bytes(pRsa->n);
+	nLen = BN_num_bytes(n);
 	nBytes = (unsigned char*) malloc(nLen);
 	if (nBytes == NULL)
 		goto out;
-	BN_bn2bin(pRsa->n, nBytes);
+	BN_bn2bin(n, nBytes);
 
 	// reading the public exponent
-	eLen = BN_num_bytes(pRsa->e);
+	eLen = BN_num_bytes(e);
 	eBytes = (unsigned char*) malloc(eLen);
 	if (eBytes == NULL)
 		goto out;
-	BN_bn2bin(pRsa->e, eBytes);
+	BN_bn2bin(e, eBytes);
 
 	encodingLength = 11 + 4 + eLen + 4 + nLen;
 	// correct depending on the MSB of e and N
@@ -135,18 +139,21 @@ xbps_pubkey2fp(struct xbps_handle *xhp, xbps_data_t pubkey)
 	/*
 	 * Compute the RSA fingerprint (MD5).
 	 */
-	EVP_MD_CTX_init(&mdctx);
-	EVP_DigestInit_ex(&mdctx, EVP_md5(), NULL);
-	EVP_DigestUpdate(&mdctx, pEncoding, encodingLength);
-	if (EVP_DigestFinal_ex(&mdctx, md_value, &md_len) == 0)
+	EVP_MD_CTX_init(mdctx);
+	EVP_DigestInit_ex(mdctx, EVP_md5(), NULL);
+	EVP_DigestUpdate(mdctx, pEncoding, encodingLength);
+	if (EVP_DigestFinal_ex(mdctx, md_value, &md_len) == 0)
 		goto out;
-	EVP_MD_CTX_cleanup(&mdctx);
+	EVP_MD_CTX_free(mdctx);
+	mdctx = NULL;
 	/*
 	 * Convert result to a compatible OpenSSH hex fingerprint.
 	 */
 	hexfpstr = fp2str(md_value, md_len);
 
 out:
+	if (mdctx)
+		EVP_MD_CTX_free(mdctx);
 	if (bio)
 		BIO_free_all(bio);
 	if (pRsa)


### PR DESCRIPTION
Maybe people are right. Openssl do make their bad API worse.
But still we need to live with it.
Lot of distro have been upgraded to openssl 1.1.x.
It is better to support 1.1.x and drop 1.0.x support. (Or add some FENCE to make both work?)
May somebody help and pick the modification and make xbps works for 1.1.x?