### PR TITLE
lib/fetch: add happy eyeballs connect algorithm (RFC8305)

### DIFF
--- a/lib/fetch/fetch.c
+++ b/lib/fetch/fetch.c
@@ -45,6 +45,8 @@ auth_t	 fetchAuthMethod;
 int	 fetchLastErrCode;
 char	 fetchLastErrString[MAXERRSTRING];
 int	 fetchTimeout;
+int	 fetchConnTimeout;
+int	 fetchConnDelay = 250;
 volatile int	 fetchRestartCalls = 1;
 int	 fetchDebug;
 

--- a/lib/fetch/fetch.h
+++ b/lib/fetch/fetch.h
@@ -173,6 +173,12 @@ extern char		 fetchLastErrString[MAXERRSTRING];
 /* I/O timeout */
 extern int		 fetchTimeout;
 
+/* Connect timeout */
+extern int		 fetchConnTimeout;
+
+/* Connect attempt delay  */
+extern int		 fetchConnDelay;
+
 /* Restart interrupted syscalls */
 extern volatile int	 fetchRestartCalls;
 


### PR DESCRIPTION
Connect to the addresses from `getaddrinfo(3)`,
alternating between address family,
starting with ipv6 and wait `fetchConnDelay`
between each connection attempt.

If a connection is established within the attempts,
use this connection and close all others.

If `connect(3)` returns `ENETUNREACH`, don't attempt more
connections with the failing address family.

If there are no more addresses to attempt,
wait for `fetchConnTimeout` and return the first established
connection.

If no connection was established within the timeouts,
close all sockets and return -1 and set errno to
`ETIMEDOUT`.