### PR TITLE
unpack: keep conf_files replaced with symlinks, unpack as .new-pkgver

### DIFF
--- a/include/xbps_api_impl.h
+++ b/include/xbps_api_impl.h
@@ -115,7 +115,7 @@ int HIDDEN xbps_cb_message(struct xbps_handle *, xbps_dictionary_t, const char *
 int HIDDEN xbps_entry_is_a_conf_file(xbps_dictionary_t, const char *);
 int HIDDEN xbps_entry_install_conf_file(struct xbps_handle *, xbps_dictionary_t,
 		xbps_dictionary_t, struct archive_entry *, const char *,
-		const char *);
+		const char *, bool);
 int HIDDEN xbps_repository_find_deps(struct xbps_handle *, xbps_array_t,
 		xbps_dictionary_t);
 xbps_dictionary_t HIDDEN xbps_find_virtualpkg_in_conf(struct xbps_handle *,

--- a/lib/package_config_files.c
+++ b/lib/package_config_files.c
@@ -63,7 +63,8 @@ xbps_entry_install_conf_file(struct xbps_handle *xhp,
 			     xbps_dictionary_t pkg_filesd,
 			     struct archive_entry *entry,
 			     const char *entry_pname,
-			     const char *pkgver)
+			     const char *pkgver,
+			     bool symlink)
 {
 	xbps_object_t obj, obj2;
 	xbps_object_iterator_t iter, iter2;
@@ -87,9 +88,10 @@ xbps_entry_install_conf_file(struct xbps_handle *xhp,
 	xbps_dbg_printf(xhp, "%s: processing conf_file %s\n",
 	    pkgver, entry_pname);
 
-	if (pkg_filesd == NULL) {
+	if (pkg_filesd == NULL || symlink) {
 		/*
-		 * File exists on disk but it's not managed by the same package.
+		 * 1. File exists on disk but it's not managed by the same package.
+		 * 2. File exists on disk as symlink.
 		 * Install it as file.new-<version>.
 		 */
 		version = xbps_pkg_version(pkgver);

--- a/tests/xbps/libxbps/shell/conf_files_test.sh
+++ b/tests/xbps/libxbps/shell/conf_files_test.sh
@@ -165,9 +165,70 @@ tc4_body() {
 	atf_check_equal $rval 0
 }
 
+# 5th test: configuration file replaced with symlink on disk, modified on upgrade.
+#	result: install new file as "<conf_file>.new-<version>".
+atf_test_case tc5
+
+tc5_head() {
+	atf_set "descr" "Tests for configuration file handling: on-disk replaced with symlink, upgrade modified"
+}
+
+tc5_body() {
+	mkdir repo
+	cd repo
+	mkdir pkg_a
+	echo "fooblah" > pkg_a/cf1.conf
+	chmod 644 pkg_a/cf1.conf
+	xbps-create -A noarch -n a-0.1_1 -s "pkg a" --config-files "/cf1.conf" pkg_a
+	atf_check_equal $? 0
+	rm -rf pkg_a
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	xbps-install -C null.conf -r rootdir --repository=$PWD -yvd a
+	atf_check_equal $? 0
+
+	mv rootdir/cf1.conf rootdir/foobar.conf
+	ln -sf foobar.conf rootdir/cf1.conf
+	sed -e 's,fooblah,blahfoo,' -i rootdir/foobar.conf
+	chmod 644 rootdir/foobar.conf
+
+	mkdir pkg_a
+	echo "bazbar" > pkg_a/cf1.conf
+	chmod 644 pkg_a/cf1.conf
+	xbps-create -A noarch -n a-0.2_1 -s "pkg a" --config-files "/cf1.conf" pkg_a
+	atf_check_equal $? 0
+
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	rm -rf pkg_a
+
+	xbps-install -C null.conf -r rootdir --repository=$PWD -yuvd
+	atf_check_equal $? 0
+
+	ls -lsa rootdir
+	test -h rootdir/cf1.conf
+	atf_check_equal $? 0
+
+	result="$(cat rootdir/cf1.conf)"
+	rval=1
+	if [ "${result}" = "blahfoo" ]; then
+		rval=0
+	fi
+
+	echo "result: ${result}"
+	echo "expected: blahfoo"
+	atf_check_equal $rval 0
+	rval=1
+	if [ -s rootdir/cf1.conf.new-0.2_1 ]; then
+		rval=0
+	fi
+	atf_check_equal $rval 0
+}
+
 atf_init_test_cases() {
 	atf_add_test_case tc1
 	atf_add_test_case tc2
 	atf_add_test_case tc3
 	atf_add_test_case tc4
+	atf_add_test_case tc5
 }


### PR DESCRIPTION
Before this patch configuration files that where not regular files, i.e. symlinks would always be removed.
This adds a test case and makes `xbps-install` always install configuration files as `.new-pkgver` if the configuration file was replaced with a symlink on disk. 

https://github.com/voidlinux/xbps/issues/276