### PR TITLE
xbps ultra fast

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ uninstall:
 	done
 
 check:
+	-rm -f result.db*
 	@./run-tests
 
 clean:

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -111,9 +111,11 @@ xbps_array_foreach_cb_multi(struct xbps_handle *xhp,
 	if (xbps_object_type(array) != XBPS_TYPE_ARRAY)
 		return 0;
 
-	arraycount = xbps_array_count(array);
-	if (arraycount == 0)
+	if (!xbps_array_count(array))
 		return 0;
+
+	/* - 1 because there's a private dict used internally */
+	arraycount = xbps_array_count(array) - 1;
 
 	maxthreads = (int)sysconf(_SC_NPROCESSORS_ONLN);
 	if (maxthreads <= 1 || arraycount <= 1) /* use single threaded routine */

--- a/tests/xbps/libxbps/find_pkg_orphans/main.c
+++ b/tests/xbps/libxbps/find_pkg_orphans/main.c
@@ -28,19 +28,19 @@
 
 static const char expected_output[] =
 	"xbps-git-20130310_2\n"
-	"xbps-triggers-1.0_1\n"
 	"libxbps-git-20130310_2\n"
 	"confuse-2.7_2\n"
-	"proplib-0.6.3_1\n"
 	"libarchive-3.1.2_1\n"
-	"libfetch-2.34_1\n"
 	"bzip2-1.0.5_1\n"
 	"liblzma-5.0.4_3\n"
 	"expat-2.1.0_3\n"
 	"attr-2.4.46_5\n"
+	"proplib-0.6.3_1\n"
+	"libfetch-2.34_1\n"
 	"libssl-1.0.1e_3\n"
 	"zlib-1.2.7_1\n"
-	"glibc-2.20_1\n";
+	"glibc-2.20_1\n"
+	"xbps-triggers-1.0_1\n";
 
 static const char expected_output_all[] =
 	"unexistent-pkg-0_1\n"

--- a/tests/xbps/libxbps/shell/Kyuafile
+++ b/tests/xbps/libxbps/shell/Kyuafile
@@ -20,6 +20,7 @@ atf_test_program{name="preserve_files_test"}
 atf_test_program{name="update_shlibs"}
 atf_test_program{name="update_hold"}
 atf_test_program{name="update_repolock"}
+atf_test_program{name="update_itself"}
 atf_test_program{name="cyclic_deps"}
 atf_test_program{name="conflicts"}
 atf_test_program{name="downgrade_hold"}

--- a/tests/xbps/libxbps/shell/Makefile
+++ b/tests/xbps/libxbps/shell/Makefile
@@ -7,7 +7,7 @@ TESTSHELL+= replace_test installmode_test obsoletefiles_test
 TESTSHELL+= issue31_test scripts_test incorrect_deps_test
 TESTSHELL+= vpkg_test install_test preserve_files_test configure_test
 TESTSHELL+= update_shlibs update_hold update_repolock cyclic_deps conflicts
-TESTSHELL+= downgrade_hold
+TESTSHELL+= update_itself downgrade_hold
 EXTRA_FILES = Kyuafile
 
 include $(TOPDIR)/mk/test.mk

--- a/tests/xbps/libxbps/shell/cyclic_deps.sh
+++ b/tests/xbps/libxbps/shell/cyclic_deps.sh
@@ -61,8 +61,6 @@ cyclic_dep_full_head() {
 }
 
 cyclic_dep_full_body() {
-	atf_set "timeout" 5
-	atf_expect_timeout "Known bug: see https://github.com/voidlinux/xbps/issues/92"
 	mkdir some_repo
 	mkdir -p pkg_A/usr/bin pkg_B/usr/bin
 	cd some_repo
@@ -86,5 +84,5 @@ cyclic_dep_full_body() {
 atf_init_test_cases() {
 	atf_add_test_case cyclic_dep_vpkg
 	atf_add_test_case cyclic_dep_vpkg2
-	#atf_add_test_case cyclic_dep_full
+	atf_add_test_case cyclic_dep_full
 }

--- a/tests/xbps/libxbps/shell/update_itself.sh
+++ b/tests/xbps/libxbps/shell/update_itself.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env atf-sh
+
+atf_test_case update_xbps
+
+update_xbps_head() {
+	atf_set "descr" "Tests for pkg updates: xbps autoupdates itself"
+}
+
+update_xbps_body() {
+	mkdir -p repo xbps
+	touch xbps/foo
+
+	cd repo
+	xbps-create -A noarch -n xbps-1.0_1 -s "xbps pkg" ../xbps
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -r root --repository=$PWD/repo -yd xbps
+	atf_check_equal $? 0
+
+	out=$(xbps-query -r root -p pkgver xbps)
+	atf_check_equal "$out" "xbps-1.0_1"
+
+	cd repo
+	xbps-create -A noarch -n xbps-1.1_1 -s "xbps pkg" ../xbps
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/xbps-1.1_1.noarch.xbps
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -r root --repository=$PWD/repo -yud
+	atf_check_equal $? 0
+
+	out=$(xbps-query -r root -p pkgver xbps)
+	atf_check_equal "$out" "xbps-1.1_1"
+}
+
+atf_test_case update_xbps_with_revdeps
+
+update_xbps_with_revdeps_head() {
+	atf_set "descr" "Tests for pkg updates: xbps autoupdates itself with revdeps"
+}
+
+update_xbps_with_revdeps_body() {
+	mkdir -p repo xbps xbps-dbg
+	touch xbps/foo xbps-dbg/foo
+
+	cd repo
+	xbps-create -A noarch -n xbps-1.0_1 -s "xbps pkg" ../xbps
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -r root --repository=$PWD/repo -yd xbps-1.0_1
+	atf_check_equal $? 0
+
+	cd repo
+	xbps-create -A noarch -n xbps-1.1_1 -s "xbps pkg" ../xbps
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+
+	xbps-create -A noarch -n xbps-dbg-1.0_1 -s "xbps-dbg pkg" --dependencies "xbps-1.0_1" ../xbps-dbg
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -r root --repository=$PWD/repo -yd xbps-dbg-1.0_1
+	atf_check_equal $? 0
+
+	cd repo
+	xbps-create -A noarch -n xbps-dbg-1.1_1 -s "xbps-dbg pkg" --dependencies "xbps-1.1_1" ../xbps-dbg
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -r root --repository=$PWD/repo -yud
+	atf_check_equal $? 0
+
+	out=$(xbps-query -r root -p pkgver xbps)
+	atf_check_equal $out "xbps-1.1_1"
+
+	out=$(xbps-query -r root -p pkgver xbps-dbg)
+	atf_check_equal $out "xbps-dbg-1.1_1"
+}
+
+atf_init_test_cases() {
+	atf_add_test_case update_xbps
+	atf_add_test_case update_xbps_with_revdeps
+}


### PR DESCRIPTION
This branch contains random bugfixes and performance improvements.

xbps_get_pkg_fulldeptree() has been rewritten for performance
and to fix those known bugs with cyclic deps.

faster: use a hash table with pkg names on the transaction dict,
 the process of collecting and sorting is now 50x faster or
 even more (kde5).

bugs: this now detects cyclic deps and returns with an appropropiate
 return value: ELOOP and ENOENT in xbps-query(1) --fulldeptree.
 Ping me if you need more details :-)

Close #77
Close #16
Close #5

