### PR TITLE
configure: added `--enable-rpath` option.

### DIFF
--- a/configure
+++ b/configure
@@ -14,6 +14,7 @@ BUILD_API_DOCS=
 BUILD_STATIC=
 SILENT=yes
 HAVE_VISIBILITY=no
+SET_RPATH=
 
 usage()
 {
@@ -39,12 +40,14 @@ for instance \`--prefix=\$HOME'.
 --dbdir=DIR		Path to the pkgdb directory [LOCALSTATEDIR/db/xbps]
 
 --verbose 		Disable silent build to see compilation details
+--enable-rpath		Link binaries with rpath '\$ORIGIN/../lib'
 --enable-api-docs 	Install XBPS API Library documentation (default disabled)
 --enable-debug		Build with debugging code and symbols (default disabled)
 --enable-fulldebug	Enables extra debugging code (default disabled)
 --enable-static 	Build XBPS static utils (default disabled)
 --enable-tests		Build and install Kyua tests (default disabled)
-			Needs atf >= 0.15 (https://code.google.com/p/kyua)
+			Needs atf >= 0.15 (https://github.com/jmmv/atf)
+			Needs kyua to run the test suite (https://github.com/jmmv/kyua)
 _EOF
 	exit 1
 }
@@ -55,6 +58,7 @@ for x; do
 	case "$opt" in
 	--enable-debug) DEBUG=yes;;
 	--enable-fulldebug) FULL_DEBUG=yes;;
+	--enable-rpath) SET_RPATH=yes;;
 	--prefix) PREFIX=$var;;
 	--exec-prefix) EPREFIX=$var;;
 	--bindir) BINDIR=$var;;
@@ -726,6 +730,11 @@ else
 	echo "SILENT =" >>$CONFIG_MK
 fi
 
+if [ "$SET_RPATH" ]; then
+	echo  "PROG_LDFLAGS = -Wl,-rpath='XORIGIN/../lib'" >>$CONFIG_MK
+	sed -i 's,XORIGIN,$$ORIGIN,' $CONFIG_MK
+fi
+
 echo
 echo "  XBPS has been configured with the following options:"
 echo
@@ -753,6 +762,9 @@ echo "   Build static programs =	$BUILD_STATIC_VALUE"
 echo "   Build with debug  =		$DEBUG"
 if [ -n "$HAVE_VISIBILITY" ]; then
 	echo "   Symbol visibility =		$HAVE_VISIBILITY"
+fi
+if [ -n "$SET_RPATH" ]; then
+	echo "   Build with rpath = 		$SET_RPATH"
 fi
 echo
 echo "  You can now run make && make install clean."

--- a/mk/prog.mk
+++ b/mk/prog.mk
@@ -49,7 +49,7 @@ endif
 $(BIN).static: $(OBJS) $(STATIC_LIBS)
 	@printf " [CCLD]\t\t$@\n"
 	${SILENT}$(CC) -static $(OBJS) $(CPPFLAGS) -L$(TOPDIR)/lib \
-		$(CFLAGS) $(LDFLAGS) $(STATIC_LIBS) -o $@
+		$(CFLAGS) $(LDFLAGS) $(PROG_LDFLAGS) $(STATIC_LIBS) -o $@
 
 $(BIN): $(OBJS)
 	@printf " [CCLD]\t\t$@\n"

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -36,5 +36,5 @@ uninstall:
 $(TEST): $(OBJS)
 	@printf " [CCLD]\t\t$@\n"
 	${SILENT}$(CC) $^ $(CPPFLAGS) -L$(TOPDIR)/lib $(CFLAGS) \
-		$(PROG_CFLAGS) $(LDFLAGS) -lxbps -latf-c -o $@
+		$(PROG_CFLAGS) $(LDFLAGS) $(PROG_LDFLAGS) -lxbps -latf-c -o $@
 


### PR DESCRIPTION
If set, binaries will have rpath set to $ORIGIN/../lib. That means
that even using defaults (--prefix=/usr), you can install
it via DESTDIR anywhere in your system and binaries will work.

This is in preparation for BSD support.