### PR TITLE
data/_xbps,_xbps_src: add ppc64+ppc(-musl) completions

### DIFF
--- a/data/_xbps
+++ b/data/_xbps
@@ -77,7 +77,7 @@ _xbps_checkvers() {
 
 _xbps_create() {
 	_arguments -s : \
-		{-A,--architecture}'[Package architecture]:architecture:(i686 i686-musl x86_64 x86_64-musl armv7l armv7l-musl armv6l armv6l-musl aarch64 aarch64-musl ppc64le ppc64le-musl ppc64-musl noarch)' \
+		{-A,--architecture}'[Package architecture]:architecture:(i686 i686-musl x86_64 x86_64-musl armv7l armv7l-musl armv6l armv6l-musl aarch64 aarch64-musl ppc64le ppc64le-musl ppc64 ppc64-musl ppc ppc-musl noarch)' \
 		{-B,--built-with}'[Package builder string]:package builder: ' \
 		{-C,--conflicts}'[Conflicts]:conflicts: ' \
 		{-D,--dependencies}'[Dependencies]:dependencies: ' \

--- a/data/_xbps_src
+++ b/data/_xbps_src
@@ -4,7 +4,7 @@ setopt localoptions extended_glob
 
 local ret=0 archs top
 
-archs=(aarch64-musl aarch64 armv6hf-musl armv6hf armv7hf-musl armv7hf i686-musl i686 mips mipsel ppc64le-musl ppc64le ppc64-musl x86_64-musl)
+archs=(aarch64-musl aarch64 armv6hf-musl armv6hf armv7hf-musl armv7hf i686-musl i686 mips mipsel ppc-musl ppc ppc64le-musl ppc64le ppc64-musl ppc64 x86_64-musl)
 
 # path to masterdir and srcpkgs.
 top=$~_comp_command1:h


### PR DESCRIPTION
We recently added the ppc64 target, so add that to completions now. Also add the 32-bit ppc ones, which have been in tree for a while.