### PR TITLE
xbps-install: make question() read the whole input line

### DIFF
--- a/bin/xbps-install/question.c
+++ b/bin/xbps-install/question.c
@@ -41,22 +41,27 @@ static bool
 question(bool preset, const char *fmt, va_list ap)
 {
 	int response;
+	bool rv = false;
 
 	vfprintf(stderr, fmt, ap);
-	if(preset)
+	if (preset)
 		fputs(" [Y/n] ", stderr);
 	else
 		fputs(" [y/N] ", stderr);
 
-	if ((response = fgetc(stdin)) != EOF) {
-		if (response == '\n')
-			return preset;
-		if (response == 'y' || response == 'Y')
-			return true;
-		if (response == 'n' || response == 'N')
-			return false;
-	}
-	return false;
+	response = fgetc(stdin);
+	if (response == '\n')
+		rv = preset;
+	else if (response == 'y' || response == 'Y')
+		rv = true;
+	else if (response == 'n' || response == 'N')
+		rv = false;
+
+	/* read the rest of the line */
+	while (response != EOF && response != '\n')
+		response = fgetc(stdin);
+
+	return rv;
 }
 
 bool


### PR DESCRIPTION
this fixes a bug:

1. ```sh
   mkdir test
   xbps-install -S -R https://alpha.de.repo.voidlinux.org/current -r test base-system
   ```
2. when it asks if you want to import the rsa key, type `y` and press enter
3. notice how it assumes yes when it asks if you want to install the packages

step 2 only reads the "y" character from stdin, so in step 3 it gets the newline and assumes the default answer