### PR TITLE
libxbps: remove dangling symlinks properly.

### DIFF
--- a/lib/package_remove.c
+++ b/lib/package_remove.c
@@ -190,7 +190,10 @@ remove_pkg_files(struct xbps_handle *xhp,
 		bool found;
 
 		xbps_dictionary_get_cstring_nocopy(obj, "file", &file);
-		snprintf(path, sizeof(path), "%s/%s", xhp->rootdir, file);
+		if (strcmp(xhp->rootdir, "/") == 0)
+			snprintf(path, sizeof(path), "%s", file);
+		else
+			snprintf(path, sizeof(path), "%s%s", xhp->rootdir, file);
 
 		if ((strcmp(key, "files") == 0) ||
 		    (strcmp(key, "conf_files") == 0)) {

--- a/tests/xbps/libxbps/shell/remove_test.sh
+++ b/tests/xbps/libxbps/shell/remove_test.sh
@@ -85,6 +85,9 @@ remove_symlinks_dangling_body() {
 	touch -f pkg_A/usr/lib/libfoo.so.1.2.0
 	ln -sf libfoo.so.2 pkg_A/usr/lib/libfoo.so.1
 	ln -sf libfoo.so.2 pkg_B/usr/lib/libfoo.so
+	ln -s ./libfoo.so pkg_B/usr/lib/libfoo.so.3
+	ln -s ./libfoo.so.4 pkg_B/usr/lib/libfoo.so.3
+	ln -s ../../../libfoo.so.4 pkg_B/usr/lib/libfoo.so.3
 
 	cd some_repo
 	xbps-create -A noarch -n A-1.0_1 -s "A pkg" ../pkg_A

--- a/tests/xbps/libxbps/shell/remove_test.sh
+++ b/tests/xbps/libxbps/shell/remove_test.sh
@@ -84,10 +84,10 @@ remove_symlinks_dangling_body() {
 	mkdir -p pkg_A/usr/lib
 	touch -f pkg_A/usr/lib/libfoo.so.1.2.0
 	ln -sf libfoo.so.2 pkg_A/usr/lib/libfoo.so.1
-	ln -sf libfoo.so.2 pkg_B/usr/lib/libfoo.so
-	ln -s ./libfoo.so pkg_B/usr/lib/libfoo.so.3
-	ln -s ./libfoo.so.4 pkg_B/usr/lib/libfoo.so.3
-	ln -s ../../../libfoo.so.4 pkg_B/usr/lib/libfoo.so.3
+	ln -sf libfoo.so.2 pkg_A/usr/lib/libfoo.so
+	ln -s ./libfoo.so pkg_A/usr/lib/libfoo.3
+	ln -s ./libfoo.so.4 pkg_A/usr/lib/libfoo.4
+	ln -s ../../../libfoo.so.4.1 pkg_A/usr/lib/libfoo.4.1
 
 	cd some_repo
 	xbps-create -A noarch -n A-1.0_1 -s "A pkg" ../pkg_A


### PR DESCRIPTION
This fixes removal of packages that contain multiple levels
of dangling symlinks, i.e faenza-icon-theme and probably others.

Close #23