### PR TITLE
fulldeptree: ignore missing local runtime dependencies

### DIFF
--- a/lib/package_fulldeptree.c
+++ b/lib/package_fulldeptree.c
@@ -152,6 +152,9 @@ ordered_depends(struct xbps_handle *xhp, xbps_dictionary_t pkgd, bool rpool)
 		} else {
 			if ((curpkgd = xbps_pkgdb_get_pkg(xhp, curdep)) == NULL)
 				curpkgd = xbps_pkgdb_get_virtualpkg(xhp, curdep);
+			/* Ignore missing local runtime dependencies, because ignorepkg */
+			if (curpkgd == NULL)
+				continue;
 		}
 		assert(curpkgd);
 		if ((curdepname = xbps_pkgpattern_name(curdep)) == NULL)


### PR DESCRIPTION
They most likely come from `ignorepkg` and without this patch
operations xbps-remove -R aborts if a dependency was ignored
at install time.