### PR TITLE
xbps alternatives: multiple fixes, new test cases.

### DIFF
--- a/configure
+++ b/configure
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Try and be like autotools configure, but without autotools
 
-VERSION=0.53
+VERSION=0.54
 
 # Ensure that we do not inherit these from env
 OS=

--- a/lib/package_alternatives.c
+++ b/lib/package_alternatives.c
@@ -366,10 +366,10 @@ xbps_alternatives_unregister(struct xbps_handle *xhp, xbps_dictionary_t pkgd)
 		if (!update && !current)
 			continue;
 
+		xbps_array_get_cstring_nocopy(array, 0, &first);
+
 		if (!current) {
 			/* get the new alternative group package */
-			first = NULL;
-			xbps_array_get_cstring_nocopy(array, 0, &first);
 			curpkgd = xbps_pkgdb_get_pkg(xhp, first);
 			assert(curpkgd);
 		}

--- a/lib/package_alternatives.c
+++ b/lib/package_alternatives.c
@@ -492,8 +492,7 @@ xbps_alternatives_register(struct xbps_handle *xhp, xbps_dictionary_t pkg_repod)
 			rv = create_symlinks(xhp,
 				xbps_dictionary_get(pkg_alternatives, keyname),
 				keyname);
-			if (alloc)
-				xbps_object_release(array);
+			xbps_object_release(array);
 			if (rv != 0)
 				break;
 		}

--- a/lib/package_alternatives.c
+++ b/lib/package_alternatives.c
@@ -355,8 +355,10 @@ xbps_alternatives_unregister(struct xbps_handle *xhp, xbps_dictionary_t pkgd)
 
 		xbps_set_cb_state(xhp, XBPS_STATE_ALTGROUP_REMOVED, 0, NULL,
 		    "%s: unregistered '%s' alternatives group", pkgver, keyname);
-		if (!update)
+		if (!update) {
 			xbps_remove_string_from_array(array, pkgname);
+			xbps_array_get_cstring_nocopy(array, 0, &first);
+		}
 
 		if (xbps_array_count(array) == 0) {
 			xbps_dictionary_remove(alternatives, keyname);
@@ -366,9 +368,7 @@ xbps_alternatives_unregister(struct xbps_handle *xhp, xbps_dictionary_t pkgd)
 		if (!update && !current)
 			continue;
 
-		xbps_array_get_cstring_nocopy(array, 0, &first);
-
-		if (!current) {
+		if (current) {
 			/* get the new alternative group package */
 			curpkgd = xbps_pkgdb_get_pkg(xhp, first);
 			assert(curpkgd);

--- a/lib/package_alternatives.c
+++ b/lib/package_alternatives.c
@@ -461,14 +461,12 @@ xbps_alternatives_register(struct xbps_handle *xhp, xbps_dictionary_t pkg_repod)
 		xbps_array_t array;
 		xbps_object_t keysym;
 		const char *keyname;
-		bool alloc = false;
 
 		keysym = xbps_array_get(allkeys, i);
 		keyname = xbps_dictionary_keysym_cstring_nocopy(keysym);
 
 		array = xbps_dictionary_get(alternatives, keyname);
 		if (array == NULL) {
-			alloc = true;
 			array = xbps_array_create();
 		} else {
 			/* already registered */
@@ -487,15 +485,13 @@ xbps_alternatives_register(struct xbps_handle *xhp, xbps_dictionary_t pkg_repod)
 		xbps_dictionary_set(alternatives, keyname, array);
 		xbps_set_cb_state(xhp, XBPS_STATE_ALTGROUP_ADDED, 0, NULL,
 		    "%s: registered '%s' alternatives group", pkgver, keyname);
-		if (alloc) {
-			/* apply alternatives for this group */
-			rv = create_symlinks(xhp,
-				xbps_dictionary_get(pkg_alternatives, keyname),
-				keyname);
-			xbps_object_release(array);
-			if (rv != 0)
-				break;
-		}
+		/* apply alternatives for this group */
+		rv = create_symlinks(xhp,
+			xbps_dictionary_get(pkg_alternatives, keyname),
+			keyname);
+		xbps_object_release(array);
+		if (rv != 0)
+			break;
 	}
 	xbps_object_release(allkeys);
 	free(pkgname);

--- a/lib/package_alternatives.c
+++ b/lib/package_alternatives.c
@@ -1,5 +1,6 @@
 /*-
- * Copyright (c) 2015 Juan Romero Pardines.
+ * Copyright (c) 2015-2019 Juan Romero Pardines.
+ * Copyright (c) 2019 Duncan Overbruck.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/lib/package_alternatives.c
+++ b/lib/package_alternatives.c
@@ -411,6 +411,7 @@ remove_obsoletes(struct xbps_handle *xhp, xbps_dictionary_t pkgd, xbps_dictionar
 			remove_symlinks(xhp, array, keyname);
 		}
 	}
+	xbps_object_release(allkeys);
 }
 
 int

--- a/lib/package_alternatives.c
+++ b/lib/package_alternatives.c
@@ -470,14 +470,18 @@ xbps_alternatives_register(struct xbps_handle *xhp, xbps_dictionary_t pkg_repod)
 		if (array == NULL) {
 			array = xbps_array_create();
 		} else {
-			/* already registered */
 			if (xbps_match_string_in_array(array, pkgname)) {
-				/* apply alternatives for this group */
+				/* already registered, update symlinks */
 				rv = create_symlinks(xhp,
 					xbps_dictionary_get(pkg_alternatives, keyname),
 					keyname);
 				if (rv != 0)
 					break;
+			} else {
+				/* not registered, add provider */
+				xbps_array_add_cstring(array, pkgname);
+				xbps_set_cb_state(xhp, XBPS_STATE_ALTGROUP_ADDED, 0, NULL,
+				    "%s: registered '%s' alternatives group", pkgver, keyname);
 			}
 			continue;
 		}

--- a/lib/package_alternatives.c
+++ b/lib/package_alternatives.c
@@ -472,8 +472,15 @@ xbps_alternatives_register(struct xbps_handle *xhp, xbps_dictionary_t pkg_repod)
 			array = xbps_array_create();
 		} else {
 			/* already registered */
-			if (xbps_match_string_in_array(array, pkgname))
-				continue;
+			if (xbps_match_string_in_array(array, pkgname)) {
+				/* apply alternatives for this group */
+				rv = create_symlinks(xhp,
+					xbps_dictionary_get(pkg_alternatives, keyname),
+					keyname);
+				if (rv != 0)
+					break;
+			}
+			continue;
 		}
 
 		xbps_array_add_cstring(array, pkgname);
@@ -485,7 +492,8 @@ xbps_alternatives_register(struct xbps_handle *xhp, xbps_dictionary_t pkg_repod)
 			rv = create_symlinks(xhp,
 				xbps_dictionary_get(pkg_alternatives, keyname),
 				keyname);
-			xbps_object_release(array);
+			if (alloc)
+				xbps_object_release(array);
 			if (rv != 0)
 				break;
 		}

--- a/tests/xbps/xbps-alternatives/main.sh
+++ b/tests/xbps/xbps-alternatives/main.sh
@@ -496,32 +496,32 @@ less_entries_update_body() {
 atf_test_case more_entries_update
 
 more_entries_update_head() {
-    atf_set "descr" "xbps-alternatives: add symlinks provided by package update"
+	atf_set "descr" "xbps-alternatives: add symlinks provided by package update"
 }
 
 more_entries_update_body() {
-    mkdir -p repo pkg_A/usr/bin pkg_B/usr/bin
-    touch pkg_A/usr/bin/A1 pkg_A/usr/bin/A2 pkg_B/usr/bin/B1
+	mkdir -p repo pkg_A/usr/bin pkg_B/usr/bin
+	touch pkg_A/usr/bin/A1 pkg_A/usr/bin/A2 pkg_B/usr/bin/B1
 
-    cd repo
-    xbps-create -A noarch -n A-1.1_1 -s "A pkg" --alternatives "1:1:/usr/bin/A1" ../pkg_A
-    atf_check_equal $? 0
-    xbps-rindex -d -a $PWD/*.xbps
-    atf_check_equal $? 0
-    cd ..
-    xbps-install -r root --repository=repo -ydv A
-    atf_check_equal $? 0
-    cd repo
-    xbps-create -A noarch -n A-1.2_1 -s "A pkg" --alternatives "1:1:/usr/bin/A1 1:2:/usr/bin/A2" ../pkg_A
-    atf_check_equal $? 0
-    xbps-rindex -d -a $PWD/*.xbps
-    atf_check_equal $? 0
-    cd ..
-    xbps-install -r root --repository=repo -ydvu
-    atf_check_equal $? 0
-    rv=0
-    [ -e root/usr/bin/2 ] || rv=1
-    atf_check_equal $rv 0
+	cd repo
+	xbps-create -A noarch -n A-1.1_1 -s "A pkg" --alternatives "1:1:/usr/bin/A1" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+	xbps-install -r root --repository=repo -ydv A
+	atf_check_equal $? 0
+	cd repo
+	xbps-create -A noarch -n A-1.2_1 -s "A pkg" --alternatives "1:1:/usr/bin/A1 1:2:/usr/bin/A2" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+	xbps-install -r root --repository=repo -ydvu
+	atf_check_equal $? 0
+	rv=0
+	[ -e root/usr/bin/2 ] || rv=1
+	atf_check_equal $rv 0
 }
 
 

--- a/tests/xbps/xbps-alternatives/main.sh
+++ b/tests/xbps/xbps-alternatives/main.sh
@@ -512,12 +512,12 @@ useless_switch_body() {
 	atf_check_equal $rv 0
 }
 
-atf_test_case remove_defprovider
+atf_test_case remove_current_provider
 
-remove_defprovider_head() {
-	atf_set "descr" "xbps-alternatives: removing default provider"
+remove_current_provider_head() {
+	atf_set "descr" "xbps-alternatives: removing current provider"
 }
-remove_defprovider_body() {
+remove_current_provider_body() {
 	mkdir -p repo pkg_A/usr/bin pkg_B/usr/bin
 	touch pkg_A/usr/bin/fileA pkg_B/usr/bin/fileB
 	cd repo
@@ -534,7 +534,7 @@ remove_defprovider_body() {
 	xbps-install -r root --repository=repo -ydv B
 	atf_check_equal $? 0
 
-	xbps-alternatives -s B
+	xbps-alternatives -r root -s B
 	atf_check_equal $? 0
 
 	xbps-remove -r root -ydv B
@@ -562,5 +562,5 @@ atf_init_test_cases() {
 	atf_add_test_case update_pkgs
 	atf_add_test_case less_entries
 	atf_add_test_case useless_switch
-	atf_add_test_case remove_defprovider
+	atf_add_test_case remove_current_provider
 }

--- a/tests/xbps/xbps-alternatives/main.sh
+++ b/tests/xbps/xbps-alternatives/main.sh
@@ -493,6 +493,38 @@ less_entries_update_body() {
 	atf_check_equal $rv 0
 }
 
+atf_test_case more_entries_update
+
+more_entries_update_head() {
+    atf_set "descr" "xbps-alternatives: add symlinks provided by package update"
+}
+
+more_entries_update_body() {
+    mkdir -p repo pkg_A/usr/bin pkg_B/usr/bin
+    touch pkg_A/usr/bin/A1 pkg_A/usr/bin/A2 pkg_B/usr/bin/B1
+
+    cd repo
+    xbps-create -A noarch -n A-1.1_1 -s "A pkg" --alternatives "1:1:/usr/bin/A1" ../pkg_A
+    atf_check_equal $? 0
+    xbps-rindex -d -a $PWD/*.xbps
+    atf_check_equal $? 0
+    cd ..
+    xbps-install -r root --repository=repo -ydv A
+    atf_check_equal $? 0
+    cd repo
+    xbps-create -A noarch -n A-1.2_1 -s "A pkg" --alternatives "1:1:/usr/bin/A1 1:2:/usr/bin/A2" ../pkg_A
+    atf_check_equal $? 0
+    xbps-rindex -d -a $PWD/*.xbps
+    atf_check_equal $? 0
+    cd ..
+    xbps-install -r root --repository=repo -ydvu
+    atf_check_equal $? 0
+    rv=0
+    [ -e root/usr/bin/2 ] || rv=1
+    atf_check_equal $rv 0
+}
+
+
 atf_test_case useless_switch
 
 useless_switch_head() {
@@ -599,6 +631,7 @@ atf_init_test_cases() {
 	atf_add_test_case update_pkgs
 	atf_add_test_case less_entries
 	atf_add_test_case less_entries_update
+	atf_add_test_case more_entries_update
 	atf_add_test_case useless_switch
 	atf_add_test_case remove_current_provider
 }

--- a/tests/xbps/xbps-alternatives/main.sh
+++ b/tests/xbps/xbps-alternatives/main.sh
@@ -433,7 +433,7 @@ update_pkgs_body() {
 
 atf_test_case less_entries
 
-less_entries_pkgs_head() {
+less_entries_head() {
 	atf_set "descr" "xbps-alternatives: remove symlinks not provided by the new alternative"
 }
 less_entries_body() {
@@ -454,6 +454,40 @@ less_entries_body() {
 	xbps-alternatives -r root -s B
 	atf_check_equal $? 0
 
+	rv=1
+	[ -e root/usr/bin/2 ] || rv=0
+	atf_check_equal $rv 0
+}
+
+atf_test_case less_entries_update
+
+less_entries_update_head() {
+	atf_set "descr" "xbps-alternatives: remove symlinks not provided by updated packages alternative"
+}
+
+less_entries_update_body() {
+	mkdir -p repo pkg_A/usr/bin pkg_B/usr/bin
+	touch pkg_A/usr/bin/A1 pkg_A/usr/bin/A2 pkg_B/usr/bin/B1
+
+	cd repo
+	xbps-create -A noarch -n A-1.1_1 -s "A pkg" --alternatives "1:1:/usr/bin/A1 1:2:/usr/bin/A2" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+
+	cd ..
+	xbps-install -r root --repository=repo -ydv A
+	atf_check_equal $? 0
+
+	cd repo
+	xbps-create -A noarch -n A-1.2_1 -s "A pkg" --alternatives "1:1:/usr/bin/A1" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+
+	cd ..
+	xbps-install -r root --repository=repo -ydvu
+	atf_check_equal $? 0
 	rv=1
 	[ -e root/usr/bin/2 ] || rv=0
 	atf_check_equal $rv 0
@@ -544,6 +578,9 @@ remove_current_provider_body() {
 	if [ "$lnk" = "$PWD/root/usr/bin/fileB" ]; then
 		rv=1
 	fi
+	if [ "$lnk" != "$PWD/root/usr/bin/fileA" ]; then
+		rv=1
+	fi
 	echo "lnk: $lnk"
 	atf_check_equal $rv 0
 }
@@ -561,6 +598,7 @@ atf_init_test_cases() {
 	atf_add_test_case set_pkg_group
 	atf_add_test_case update_pkgs
 	atf_add_test_case less_entries
+	atf_add_test_case less_entries_update
 	atf_add_test_case useless_switch
 	atf_add_test_case remove_current_provider
 }


### PR DESCRIPTION
In the !current branch, "first" wasn't initialized so it displayed garbage:

```
Removing `pinentry-tty-1.1.0_5' ...
Removing 'pinentry' alternatives group symlink: pinentry
pinentry-tty-1.1.0_5: unregistered 'pinentry' alternatives group
Switched 'pinentry' alternatives group to 'p
o@�'
Creating 'pinentry' alternatives group symlink: pinentry -> /usr/bin/pinentry-tty
Removed file `/usr/bin/pinentry-tty'
Removed `pinentry-tty-1.1.0_5' successfully.
```

With my fix:
```
Removing `pinentry-tty-1.1.0_5' ...
Removing 'pinentry' alternatives group symlink: pinentry
pinentry-tty-1.1.0_5: unregistered 'pinentry' alternatives group
Switched 'pinentry' alternatives group to 'pinentry'
Creating 'pinentry' alternatives group symlink: pinentry -> /usr/bin/pinentry-tty
Removed file `/usr/bin/pinentry-tty'
Removed `pinentry-tty-1.1.0_5' successfully.
```

Signed-off-by: Juan RP <xtraeme@gmail.com>