### PR TITLE
xbps-digest(1): new utility that replaces "xbps-uhelper digest".

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ bin/xbps-uhelper/xbps-uhelper
 bin/xbps-uchroot/xbps-uchroot
 bin/xbps-checkvers/xbps-checkvers
 bin/xbps-uunshare/xbps-uunshare
+bin/xbps-digest/xbps-digest
 *.static
 *.so*
 *.o

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -12,6 +12,7 @@ SUBDIRS +=	xbps-rindex
 SUBDIRS +=	xbps-uhelper
 SUBDIRS +=	xbps-checkvers
 SUBDIRS +=	xbps-fbulk
+SUBDIRS +=	xbps-digest
 
 ifeq (${XBPS_OS},linux)
 SUBDIRS +=	xbps-uchroot

--- a/bin/xbps-alternatives/xbps-alternatives.1
+++ b/bin/xbps-alternatives/xbps-alternatives.1
@@ -1,4 +1,4 @@
-.Dd October 31, 2015
+.Dd June 12, 2019
 .Dt XBPS-ALTERNATIVES 1
 .Sh NAME
 .Nm xbps-alternatives
@@ -73,6 +73,7 @@ Default cache directory to store downloaded binary packages.
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
+.Xr xbps-digest 1 ,
 .Xr xbps-fbulk 1 ,
 .Xr xbps-install 1 ,
 .Xr xbps-pkgdb 1 ,

--- a/bin/xbps-checkvers/xbps-checkvers.1
+++ b/bin/xbps-checkvers/xbps-checkvers.1
@@ -1,4 +1,4 @@
-.Dd October 28, 2015
+.Dd June 12, 2019
 .Dt XBPS-CHECKVERS 1
 .Sh NAME
 .Nm xbps-checkvers
@@ -51,6 +51,7 @@ Show the version information.
 .Sh SEE ALSO
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
+.Xr xbps-digest 1 ,
 .Xr xbps-fbulk 1 ,
 .Xr xbps-install 1 ,
 .Xr xbps-pkgdb 1 ,

--- a/bin/xbps-create/xbps-create.1
+++ b/bin/xbps-create/xbps-create.1
@@ -1,4 +1,4 @@
-.Dd April 23, 2016
+.Dd June 12, 2019
 .Dt XBPS-CREATE 1
 .Sh NAME
 .Nm xbps-create
@@ -93,6 +93,7 @@ The package changelog string.
 .Sh SEE ALSO
 .Xr xbps-checkvers 1 ,
 .Xr xbps-dgraph 1 ,
+.Xr xbps-digest 1 ,
 .Xr xbps-fbulk 1 ,
 .Xr xbps-install 1 ,
 .Xr xbps-pkgdb 1 ,

--- a/bin/xbps-dgraph/xbps-dgraph.1
+++ b/bin/xbps-dgraph/xbps-dgraph.1
@@ -1,4 +1,4 @@
-.Dd October 28, 2015
+.Dd June 12, 2019
 .Dt XBPS-DGRAPH 1
 .Sh NAME
 .Nm xbps-dgraph
@@ -125,6 +125,7 @@ Default cache directory to store downloaded binary packages.
 .Xr xbps.d 5 ,
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
+.Xr xbps-digest 1 ,
 .Xr xbps-fbulk 1 ,
 .Xr xbps-install 1 ,
 .Xr xbps-pkgdb 1 ,

--- a/bin/xbps-digest/Makefile
+++ b/bin/xbps-digest/Makefile
@@ -1,0 +1,7 @@
+TOPDIR = ../..
+-include $(TOPDIR)/config.mk
+
+BIN = xbps-digest
+OBJS = main.o
+
+include $(TOPDIR)/mk/prog.mk

--- a/bin/xbps-digest/main.c
+++ b/bin/xbps-digest/main.c
@@ -1,0 +1,107 @@
+/*-
+ * Copyright (c) 2019 Juan Romero Pardines.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <errno.h>
+#include <unistd.h>
+#include <getopt.h>
+
+#include <xbps.h>
+
+static void __attribute__((noreturn))
+usage(void)
+{
+	fprintf(stdout,
+	"Usage: xbps-digest [options] [file] [file+N]\n"
+	"\n"
+	"OPTIONS:\n"
+	" -h\t\tShow usage()\n"
+	" -m <sha256>\tSelects the digest mode, sha256 (default)\n"
+	" -V\t\tPrints the xbps release version\n"
+	"\n"
+	"NOTES\n"
+	" If [file] not set, reads from stdin.\n");
+	exit(EXIT_FAILURE);
+}
+
+int
+main(int argc, char **argv)
+{
+	int c;
+	char *hash = NULL;
+	const char *mode = NULL, *progname = argv[0];
+	const struct option longopts[] = {
+		{ NULL, 0, NULL, 0 }
+	};
+
+	while ((c = getopt_long(argc, argv, "m:hV", longopts, NULL)) != -1) {
+		switch (c) {
+		case 'm':
+			mode = optarg;
+			break;
+		case 'V':
+			printf("%s\n", XBPS_RELVER);
+			exit(EXIT_SUCCESS);
+		case '?':
+		case 'h':
+		default:
+			usage();
+		}
+	}
+
+	argc -= optind;
+	argv += optind;
+
+	if (mode && strcmp(mode, "sha256")) {
+		/* sha256 is the only supported mode currently */
+		fprintf(stderr, "%s: unsupported digest mode\n", progname);
+		exit(EXIT_FAILURE);
+	}
+
+	if (argc < 1) {
+		hash = xbps_file_hash("/dev/stdin");
+		if (hash == NULL)
+			exit(EXIT_FAILURE);
+
+		printf("%s\n", hash);
+		free(hash);
+	} else {
+		for (int i = 0; i < argc; i++) {
+			hash = xbps_file_hash(argv[i]);
+			if (hash == NULL) {
+				fprintf(stderr,
+				    "%s: couldn't get hash for %s (%s)\n",
+				progname, argv[i], strerror(errno));
+				exit(EXIT_FAILURE);
+			}
+			printf("%s\n", hash);
+			free(hash);
+		}
+	}
+	exit(EXIT_SUCCESS);
+}

--- a/bin/xbps-digest/xbps-digest.1
+++ b/bin/xbps-digest/xbps-digest.1
@@ -1,0 +1,51 @@
+.Dd June 12, 2019
+.Dt XBPS-DIGEST 1
+.Sh NAME
+.Nm xbps-digest
+.Nd XBPS utility to generate message digests
+.Sh SYNOPSIS
+.Nm xbps-digest
+.Op OPTIONS
+.Op FILE
+.Op FILE+N
+.Sh DESCRIPTION
+The
+.Nm
+utility generates message digests for specified
+.Ar FILE
+or
+.Ar stdin
+if unset.
+.Sh OPTIONS
+.Bl -tag -width -x
+.It Fl m, Fl -mode Ar mode
+Sets the message digest mode. Supported:
+.Ar sha256 .
+If unset, defaults to
+.Ar sha256 .
+.It Fl h, Fl -help
+Show the help message.
+.It Fl V, Fl -version
+Show the version information.
+.El
+.Sh SEE ALSO
+.Xr xbps.d 5 ,
+.Xr xbps-checkvers 1 ,
+.Xr xbps-create 1 ,
+.Xr xbps-dgraph 1 ,
+.Xr xbps-fbulk 1 ,
+.Xr xbps-install 1 ,
+.Xr xbps-pkgdb 1 ,
+.Xr xbps-query 1 ,
+.Xr xbps-reconfigure 1 ,
+.Xr xbps-remove 1 ,
+.Xr xbps-rindex  1 ,
+.Xr xbps-uchroot 1 ,
+.Xr xbps-uunshare 1
+.Sh AUTHORS
+.An Juan Romero Pardines <xtraeme@gmail.com>
+.Sh BUGS
+Probably, but I try to make this not happen. Use it under your own
+responsibility and enjoy your life.
+.Pp
+Report bugs at https://github.com/void-linux/xbps/issues

--- a/bin/xbps-fbulk/xbps-fbulk.1
+++ b/bin/xbps-fbulk/xbps-fbulk.1
@@ -1,4 +1,4 @@
-.Dd October 28, 2015
+.Dd June 12, 2019
 .Dt XBPS-FBULK 1
 .Sh NAME
 .Nm xbps-fbulk
@@ -88,6 +88,7 @@ and the kernel supports the overlay filesystem, introduced in 4.0.
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
+.Xr xbps-digest 1 ,
 .Xr xbps-install 1 ,
 .Xr xbps-pkgdb 1 ,
 .Xr xbps-query 1 ,

--- a/bin/xbps-install/xbps-install.1
+++ b/bin/xbps-install/xbps-install.1
@@ -1,4 +1,4 @@
-.Dd September 20, 2016
+.Dd June 12, 2019
 .Dt XBPS-INSTALL 1
 .Sh NAME
 .Nm xbps-install
@@ -155,6 +155,7 @@ Default cache directory to store downloaded binary packages.
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
+.Xr xbps-digest 1 ,
 .Xr xbps-fbulk 1 ,
 .Xr xbps-pkgdb 1 ,
 .Xr xbps-query 1 ,

--- a/bin/xbps-pkgdb/xbps-pkgdb.1
+++ b/bin/xbps-pkgdb/xbps-pkgdb.1
@@ -1,4 +1,4 @@
-.Dd September 20, 2016
+.Dd June 12, 2019
 .Dt XBPS-PKGDB 1
 .Sh NAME
 .Nm xbps-pkgdb
@@ -125,6 +125,7 @@ Default cache directory to store downloaded binary packages.
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
+.Xr xbps-digest 1 ,
 .Xr xbps-fbulk 1 ,
 .Xr xbps-install 1 ,
 .Xr xbps-query 1 ,

--- a/bin/xbps-query/xbps-query.1
+++ b/bin/xbps-query/xbps-query.1
@@ -1,4 +1,4 @@
-.Dd May 16, 2015
+.Dd June 12, 2019
 .Dt XBPS-QUERY 1
 .Sh NAME
 .Nm xbps-query
@@ -269,6 +269,7 @@ Default cache directory to store downloaded binary packages.
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
+.Xr xbps-digest 1 ,
 .Xr xbps-install 1 ,
 .Xr xbps-pkgdb 1 ,
 .Xr xbps-reconfigure 1 ,

--- a/bin/xbps-reconfigure/xbps-reconfigure.1
+++ b/bin/xbps-reconfigure/xbps-reconfigure.1
@@ -1,4 +1,4 @@
-.Dd October 28, 2015
+.Dd June 12, 2019
 .Dt XBPS-RECONFIGURE 1
 .Sh NAME
 .Nm xbps-reconfigure
@@ -78,6 +78,7 @@ Default cache directory to store downloaded binary packages.
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
+.Xr xbps-digest 1 ,
 .Xr xbps-fbulk 1 ,
 .Xr xbps-install 1 ,
 .Xr xbps-pkgdb 1 ,

--- a/bin/xbps-remove/xbps-remove.1
+++ b/bin/xbps-remove/xbps-remove.1
@@ -1,4 +1,4 @@
-.Dd October 28, 2015
+.Dd June 12, 2019
 .Dt XBPS-REMOVE 1
 .Sh NAME
 .Nm xbps-remove
@@ -114,6 +114,7 @@ Default cache directory to store downloaded binary packages.
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
+.Xr xbps-digest 1 ,
 .Xr xbps-fbulk 1 ,
 .Xr xbps-install 1 ,
 .Xr xbps-pkgdb 1 ,

--- a/bin/xbps-rindex/xbps-rindex.1
+++ b/bin/xbps-rindex/xbps-rindex.1
@@ -1,4 +1,4 @@
-.Dd October 28, 2015
+.Dd June 12, 2019
 .Dt XBPS-RINDEX 1
 .Sh NAME
 .Nm xbps-rindex
@@ -96,6 +96,7 @@ a repository. Otherwise it will ask you to enter the passphrase on the terminal.
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
+.Xr xbps-digest 1 ,
 .Xr xbps-fbulk 1 ,
 .Xr xbps-install 1 ,
 .Xr xbps-pkgdb 1 ,

--- a/bin/xbps-uchroot/xbps-uchroot.1
+++ b/bin/xbps-uchroot/xbps-uchroot.1
@@ -1,4 +1,4 @@
-.Dd October 28, 2015
+.Dd June 12, 2019
 .Dt XBPS-UCHROOT 1
 .Sh NAME
 .Nm xbps-uchroot
@@ -75,6 +75,7 @@ other Operating Systems. The following kernel options must be enabled:
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
+.Xr xbps-digest 1 ,
 .Xr xbps-fbulk 1 ,
 .Xr xbps-install 1 ,
 .Xr xbps-pkgdb 1 ,

--- a/bin/xbps-uhelper/main.c
+++ b/bin/xbps-uhelper/main.c
@@ -44,7 +44,7 @@ usage(void)
 	"usage: xbps-uhelper [options] [action] [args]\n"
 	"\n"
 	"  Available actions:\n"
-	"    binpkgarch, binpkgver, cmpver, digest, fetch, getpkgdepname,\n"
+	"    binpkgarch, binpkgver, cmpver, fetch, getpkgdepname,\n"
 	"    getpkgname, getpkgrevision, getpkgversion, pkgmatch, version,\n"
 	"    real-version, arch, getsystemdir\n"
 	"\n"
@@ -52,7 +52,6 @@ usage(void)
 	"    binpkgarch\t<binpkg>\n"
 	"    binpkgver\t<binpkg>\n"
 	"    cmpver\t\t<instver> <reqver>\n"
-	"    digest\t\t<file> <file1+N>\n"
 	"    fetch\t\t<URL[>filename]> <URL1+N[>filename]>\n"
 	"    getpkgdepname\t<string>\n"
 	"    getpkgdepversion\t<string>\n"
@@ -71,7 +70,6 @@ usage(void)
 	"\n"
 	"  Examples:\n"
 	"    $ xbps-uhelper cmpver 'foo-1.0_1' 'foo-2.1_1'\n"
-	"    $ xbps-uhelper digest file ...\n"
 	"    $ xbps-uhelper fetch http://www.foo.org/file.blob ...\n"
 	"    $ xbps-uhelper getpkgdepname 'foo>=0'\n"
 	"    $ xbps-uhelper getpkgdepversion 'foo>=0'\n"
@@ -105,7 +103,7 @@ main(int argc, char **argv)
 	struct xbps_handle xh;
 	struct xferstat xfer;
 	const char *version, *rootdir = NULL, *confdir = NULL;
-	char *pkgname, *hash, *filename;
+	char *pkgname, *filename;
 	int flags = 0, c, rv = 0;
 	const struct option longopts[] = {
 		{ NULL, 0, NULL, 0 }
@@ -291,21 +289,6 @@ main(int argc, char **argv)
 			usage();
 
 		printf("%s\n", XBPS_SYSDEFCONF_PATH);
-	} else if (strcmp(argv[0], "digest") == 0) {
-		/* Prints SHA256 hashes for specified files */
-		if (argc < 2)
-			usage();
-
-		for (int i = 1; i < argc; i++) {
-			hash = xbps_file_hash(argv[i]);
-			if (hash == NULL) {
-				fprintf(stderr,
-				    "E: couldn't get hash for %s (%s)\n",
-				    argv[i], strerror(errno));
-				exit(EXIT_FAILURE);
-			}
-			printf("%s\n", hash);
-		}
 	} else if (strcmp(argv[0], "fetch") == 0) {
 		/* Fetch a file from specified URL */
 		if (argc < 2)

--- a/bin/xbps-uunshare/xbps-uunshare.1
+++ b/bin/xbps-uunshare/xbps-uunshare.1
@@ -1,4 +1,4 @@
-.Dd October 28, 2015
+.Dd June 12, 2019
 .Dt XBPS-UUNSHARE 1
 .Sh NAME
 .Nm xbps-uunshare
@@ -54,6 +54,7 @@ other Operating Systems. The following kernel options must be enabled:
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
+.Xr xbps-digest 1 ,
 .Xr xbps-fbulk 1 ,
 .Xr xbps-install 1 ,
 .Xr xbps-pkgdb 1 ,

--- a/data/xbps.d.5
+++ b/data/xbps.d.5
@@ -1,4 +1,4 @@
-.Dd December 30, 2014
+.Dd June 12, 2019
 .Dt XBPS-D 5
 .Sh NAME
 .Nm xbps.d
@@ -141,6 +141,7 @@ Default cache directory to store downloaded binary packages.
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
+.Xr xbps-digest 1 ,
 .Xr xbps-install 1 ,
 .Xr xbps-pkgdb 1 ,
 .Xr xbps-query 1 ,


### PR DESCRIPTION
See the manual page:

XBPS-DIGEST(1)              General Commands Manual             XBPS-DIGEST(1)

NAME
     xbps-digest - XBPS utility to generate message digests

SYNOPSIS
     xbps-digest [OPTIONS] [FILE] [FILE+N]

DESCRIPTION
     The xbps-digest utility generates message digests for specified FILE or
     stdin if unset.

OPTIONS
     -m, --mode mode
         Sets the message digest mode. Supported: sha256.  If unset, defaults
         to sha256.

     -h, --help
         Show the help message.

     -V, --version
         Show the version information.

SEE ALSO
     xbps.d(5), xbps-checkvers(1), xbps-create(1), xbps-dgraph(1),
     xbps-fbulk(1), xbps-install(1), xbps-pkgdb(1), xbps-query(1),
     xbps-reconfigure(1), xbps-remove(1), xbps-rindex(1), xbps-uchroot(1),
     xbps-uunshare(1)

AUTHORS
     Juan Romero Pardines <xtraeme@gmail.com>

BUGS
     Probably, but I try to make this not happen. Use it under your own
     responsibility and enjoy your life.

     Report bugs at https://github.com/void-linux/xbps/issues

                                 June 12, 2019

Signed-off-by: Juan RP <xtraeme@gmail.com>