### PR TITLE
xbps-checkvers: implement -s,--show-all.

### DIFF
--- a/bin/xbps-checkvers/xbps-checkvers.1
+++ b/bin/xbps-checkvers/xbps-checkvers.1
@@ -1,4 +1,4 @@
-.Dd June 12, 2019
+.Dd June 13, 2019
 .Dt XBPS-CHECKVERS 1
 .Sh NAME
 .Nm xbps-checkvers
@@ -46,10 +46,14 @@ Check for outdated installed packages rather than in repositories.
 Repository to be added to the top of the list. This option can be specified multiple times.
 .It Fl r, Fl -rootdir Ar dir
 Specifies a full path for the target root directory.
-.It Fl s, Fl -show-missing
-Shows missing binary packages comparing against the
+.It Fl s, Fl -show-all
+List all packages found in the
 .Nm void-packages
-tree.
+tree and prints version available in repository and srcpkgs with the following format:
+.Ar pkgname repover srcver .
+If any version can't be resolved,
+.Em ?
+is printed instead.
 .It Fl V, Fl -version
 Show the version information.
 .El

--- a/tests/xbps/xbps-checkvers/checkvers.sh
+++ b/tests/xbps/xbps-checkvers/checkvers.sh
@@ -3,7 +3,7 @@
 atf_test_case srcpkg_older
 
 srcpkg_older_head() {
-	atf_set "descr" "xbps-checkvers(8): test when srcpkg contains an older version"
+	atf_set "descr" "xbps-checkvers(1): test when srcpkg contains an older version"
 }
 srcpkg_older_body() {
 	mkdir -p some_repo pkg_A void-packages/srcpkgs/A
@@ -22,7 +22,7 @@ EOF
 	xbps-rindex -d -a $PWD/*.xbps
 	atf_check_equal $? 0
 	cd ..
-	out=`xbps-checkvers -R $PWD/some_repo -D $PWD/void-packages`
+	out=$(xbps-checkvers -R $PWD/some_repo -D $PWD/void-packages)
 	atf_check_equal $? 0
 	atf_check_equal "$out" ""
 }
@@ -30,7 +30,7 @@ EOF
 atf_test_case srcpkg_older_with_refs
 
 srcpkg_older_with_refs_head() {
-	atf_set "descr" "xbps-checkvers(8): test when srcpkg contains an older version with refs"
+	atf_set "descr" "xbps-checkvers(1): test when srcpkg contains an older version with refs"
 }
 srcpkg_older_with_refs_body() {
 	mkdir -p some_repo pkg_A void-packages/srcpkgs/A
@@ -51,7 +51,7 @@ EOF
 	xbps-rindex -d -a $PWD/*.xbps
 	atf_check_equal $? 0
 	cd ..
-	out=`xbps-checkvers -R $PWD/some_repo -D $PWD/void-packages`
+	out=$(xbps-checkvers -R $PWD/some_repo -D $PWD/void-packages)
 	atf_check_equal $? 0
 	atf_check_equal "$out" ""
 }
@@ -59,7 +59,7 @@ EOF
 atf_test_case srcpkg_newer
 
 srcpkg_newer_head() {
-	atf_set "descr" "xbps-checkvers(8): test when srcpkg contains a newer version"
+	atf_set "descr" "xbps-checkvers(1): test when srcpkg contains a newer version"
 }
 srcpkg_newer_body() {
 	mkdir -p some_repo pkg_A void-packages/srcpkgs/A
@@ -78,15 +78,15 @@ EOF
 	xbps-rindex -d -a $PWD/*.xbps
 	atf_check_equal $? 0
 	cd ..
-	out=`xbps-checkvers -R $PWD/some_repo -D $PWD/void-packages`
+	out=$(xbps-checkvers -R $PWD/some_repo -D $PWD/void-packages)
 	atf_check_equal $? 0
-	atf_check_equal "$out" "pkgname: A repover: 1.0_1 srcpkgver: 1.1_1"
+	atf_check_equal "$out" "A 1.0_1 1.1_1"
 }
 
 atf_test_case srcpkg_newer_with_refs
 
 srcpkg_newer_with_refs_head() {
-	atf_set "descr" "xbps-checkvers(8): test when srcpkg contains a newer version with refs"
+	atf_set "descr" "xbps-checkvers(1): test when srcpkg contains a newer version with refs"
 }
 srcpkg_newer_with_refs_body() {
 	mkdir -p some_repo pkg_A void-packages/srcpkgs/A
@@ -107,15 +107,15 @@ EOF
 	xbps-rindex -d -a $PWD/*.xbps
 	atf_check_equal $? 0
 	cd ..
-	out=`xbps-checkvers -R $PWD/some_repo -D $PWD/void-packages`
+	out=$(xbps-checkvers -R $PWD/some_repo -D $PWD/void-packages)
 	atf_check_equal $? 0
-	atf_check_equal "$out" "pkgname: A repover: 1.0_1 srcpkgver: 1.1_1"
+	atf_check_equal "$out" "A 1.0_1 1.1_1"
 }
 
 atf_test_case srcpkg_newer_with_refs_and_source
 
 srcpkg_newer_with_refs_and_source_head() {
-	atf_set "descr" "xbps-checkvers(8): test when srcpkg contains a newer version with refs and file sourcing"
+	atf_set "descr" "xbps-checkvers(1): test when srcpkg contains a newer version with refs and file sourcing"
 }
 srcpkg_newer_with_refs_and_source_body() {
 	mkdir -p some_repo pkg_A void-packages/srcpkgs/A
@@ -137,15 +137,15 @@ EOF
 	xbps-rindex -d -a $PWD/*.xbps
 	atf_check_equal $? 0
 	cd ..
-	out=`xbps-checkvers -R $PWD/some_repo -D $PWD/void-packages`
+	out=$(xbps-checkvers -R $PWD/some_repo -D $PWD/void-packages)
 	atf_check_equal $? 0
-	atf_check_equal "$out" "pkgname: A repover: 1.0_1 srcpkgver: 1.1_1"
+	atf_check_equal "$out" "A 1.0_1 1.1_1"
 }
 
 atf_test_case srcpkg_missing_pkgname
 
 srcpkg_missing_pkgname_head() {
-	atf_set "descr" "xbps-checkvers(8): test when srcpkg does not set pkgname"
+	atf_set "descr" "xbps-checkvers(1): test when srcpkg does not set pkgname"
 }
 srcpkg_missing_pkgname_body() {
 	mkdir -p some_repo pkg_A void-packages/srcpkgs/A
@@ -171,7 +171,7 @@ EOF
 atf_test_case srcpkg_missing_version
 
 srcpkg_missing_version_head() {
-	atf_set "descr" "xbps-checkvers(8): test when srcpkg does not set version"
+	atf_set "descr" "xbps-checkvers(1): test when srcpkg does not set version"
 }
 srcpkg_missing_version_body() {
 	mkdir -p some_repo pkg_A void-packages/srcpkgs/A
@@ -197,7 +197,7 @@ EOF
 atf_test_case srcpkg_missing_revision
 
 srcpkg_missing_revision_head() {
-	atf_set "descr" "xbps-checkvers(8): test when srcpkg does not set revision"
+	atf_set "descr" "xbps-checkvers(1): test when srcpkg does not set revision"
 }
 srcpkg_missing_revision_body() {
 	mkdir -p some_repo pkg_A void-packages/srcpkgs/A
@@ -223,7 +223,7 @@ EOF
 atf_test_case srcpkg_missing_pkgver
 
 srcpkg_missing_pkgver_head() {
-	atf_set "descr" "xbps-checkvers(8): test when srcpkg does not set pkgname/version"
+	atf_set "descr" "xbps-checkvers(1): test when srcpkg does not set pkgname/version"
 }
 srcpkg_missing_pkgver_body() {
 	mkdir -p some_repo pkg_A void-packages/srcpkgs/A
@@ -249,7 +249,7 @@ EOF
 atf_test_case srcpkg_missing_pkgverrev
 
 srcpkg_missing_pkgverrev_head() {
-	atf_set "descr" "xbps-checkvers(8): test when srcpkg does not set pkgname/version/revision"
+	atf_set "descr" "xbps-checkvers(1): test when srcpkg does not set pkgname/version/revision"
 }
 srcpkg_missing_pkgverrev_body() {
 	mkdir -p some_repo pkg_A void-packages/srcpkgs/A
@@ -275,7 +275,7 @@ EOF
 atf_test_case srcpkg_with_a_ref
 
 srcpkg_with_a_ref_head() {
-	atf_set "descr" "xbps-checkvers(8): test when srcpkg does set a ref in pkgname/version/revision"
+	atf_set "descr" "xbps-checkvers(1): test when srcpkg does set a ref in pkgname/version/revision"
 }
 srcpkg_with_a_ref_body() {
 	mkdir -p some_repo pkg_A void-packages/srcpkgs/foo
@@ -296,13 +296,13 @@ EOF
 	cd ..
 	xbps-checkvers -R $PWD/some_repo -D $PWD/void-packages >out
 	atf_check_equal $? 0
-	atf_check_equal "$(cat out)" "pkgname: foo repover: 1.0_1 srcpkgver: 1.1_1"
+	atf_check_equal "$(cat out)" "foo 1.0_1 1.1_1"
 }
 
 atf_test_case srcpkg_with_a_ref_and_comment
 
 srcpkg_with_a_ref_and_comment_head() {
-	atf_set "descr" "xbps-checkvers(8): test when srcpkg does set a ref in pkgname/version/revision with a comment"
+	atf_set "descr" "xbps-checkvers(1): test when srcpkg does set a ref in pkgname/version/revision with a comment"
 }
 srcpkg_with_a_ref_and_comment_body() {
 	mkdir -p some_repo pkg_A void-packages/srcpkgs/foo
@@ -322,13 +322,13 @@ EOF
 	cd ..
 	xbps-checkvers -R $PWD/some_repo -D $PWD/void-packages >out
 	atf_check_equal $? 0
-	atf_check_equal "$(cat out)" "pkgname: foo repover: 1.0_1 srcpkgver: 1.1_1"
+	atf_check_equal "$(cat out)" "foo 1.0_1 1.1_1"
 }
 
 atf_test_case reverts
 
 reverts_head() {
-	atf_set "descr" "xbps-checkvers(8): test with reverts"
+	atf_set "descr" "xbps-checkvers(1): test with reverts"
 }
 
 reverts_body() {
@@ -349,15 +349,15 @@ EOF
 	xbps-rindex -d -a $PWD/*.xbps
 	atf_check_equal $? 0
 	cd ..
-	out=`xbps-checkvers -R $PWD/some_repo -D $PWD/void-packages`
+	out=$(xbps-checkvers -R $PWD/some_repo -D $PWD/void-packages)
 	atf_check_equal $? 0
-	atf_check_equal "$out" "pkgname: A repover: 1.1_1 srcpkgver: 1.0_1"
+	atf_check_equal "$out" "A 1.1_1 1.0_1"
 }
 
 atf_test_case reverts_alpha
 
 reverts_alpha_head() {
-	atf_set "descr" "xbps-checkvers(8): test with reverts containing an alphanumeric character"
+	atf_set "descr" "xbps-checkvers(1): test with reverts containing an alphanumeric character"
 }
 
 reverts_alpha_body() {
@@ -379,9 +379,9 @@ EOF
 	atf_check_equal $? 0
 	cd ..
 	xbps-checkvers -R $PWD/some_repo -D $PWD/void-packages
-	out=`xbps-checkvers -R $PWD/some_repo -D $PWD/void-packages`
+	out=$(xbps-checkvers -R $PWD/some_repo -D $PWD/void-packages)
 	atf_check_equal $? 0
-	atf_check_equal "$out" "pkgname: fs-utils repover: 1.10_1 srcpkgver: 1.10_1"
+	atf_check_equal "$out" "fs-utils 1.10_1 1.10_1"
 }
 
 atf_init_test_cases() {


### PR DESCRIPTION
This replaces -s,--show-missing. This now prints all processed packages
and outputs in the following format:

pkgname repover srcver

if `repover` or `srcver` can't be known, '?' is print.

Will be used in xbps-src soon. Thanks to @duncaen for ideas.

Signed-off-by: Juan RP <xtraeme@gmail.com>