### PR TITLE
libxbps: fix xbps autoupdate when its revdeps are up-to-date.

### DIFF
--- a/lib/transaction_ops.c
+++ b/lib/transaction_ops.c
@@ -251,6 +251,8 @@ xbps_transaction_update_packages(struct xbps_handle *xhp)
 		rv = trans_find_pkg(xhp, pkgname, false, false);
 		free(pkgname);
 
+		xbps_dbg_printf(xhp, "%s: trans_find_pkg xbps: %d\n", __func__, rv);
+
 		if (rv == 0) {
 			/* new version found, take into account its revdeps */
 			xbps_array_t rdeps;
@@ -265,12 +267,14 @@ xbps_transaction_update_packages(struct xbps_handle *xhp)
 				assert(curpkgn);
 				rv = trans_find_pkg(xhp, curpkgn, false, false);
 				free(curpkgn);
-				if (rv != 0 && rv != EEXIST)
+				if (rv && rv != ENOENT && rv != EEXIST && rv != ENODEV)
 					return rv;
+
+				rv = 0;
 			}
 
 			return rv;
-		} else if (rv == EEXIST || rv == ENOENT) {
+		} else if (rv == ENOENT || rv == EEXIST || rv == ENODEV) {
 			/* no update */
 			;
 		} else {
@@ -327,7 +331,7 @@ xbps_transaction_update_pkg(struct xbps_handle *xhp, const char *pkg)
 		assert(curpkgn);
 		rv = trans_find_pkg(xhp, curpkgn, false, false);
 		free(curpkgn);
-		if (rv != 0 && rv != EEXIST)
+		if (rv && rv != ENOENT && rv != EEXIST && rv != ENODEV)
 			return rv;
 	}
 	return trans_find_pkg(xhp, pkg, false, false);
@@ -350,7 +354,7 @@ xbps_transaction_install_pkg(struct xbps_handle *xhp, const char *pkg,
 		assert(curpkgn);
 		rv = trans_find_pkg(xhp, curpkgn, false, false);
 		free(curpkgn);
-		if (rv != 0 && rv != EEXIST)
+		if (rv && rv != ENOENT && rv != EEXIST && rv != ENODEV)
 			return rv;
 	}
 	return trans_find_pkg(xhp, pkg, reinstall, false);

--- a/tests/xbps/libxbps/shell/update_itself.sh
+++ b/tests/xbps/libxbps/shell/update_itself.sh
@@ -89,7 +89,53 @@ update_xbps_with_revdeps_body() {
 	atf_check_equal $out "xbps-dbg-1.1_1"
 }
 
+atf_test_case update_xbps_with_uptodate_revdeps
+
+update_xbps_with_uptodate_revdeps_head() {
+	atf_set "descr" "Tests for pkg updates: xbps autoupdates itself with already up-to-date revdeps"
+}
+
+update_xbps_with_uptodate_revdeps_body() {
+	mkdir -p repo xbps base-system
+	touch xbps/foo base-system/foo
+
+	cd repo
+	xbps-create -A noarch -n xbps-1.0_1 -s "xbps pkg" ../xbps
+	atf_check_equal $? 0
+	xbps-create -A noarch -n base-system-1.0_1 -s "base-system pkg" --dependencies "xbps>=0" ../base-system
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -r root --repository=$PWD/repo -yd base-system
+	atf_check_equal $? 0
+
+	out=$(xbps-query -r root -p pkgver xbps)
+	atf_check_equal $out "xbps-1.0_1"
+
+	out=$(xbps-query -r root -p pkgver base-system)
+	atf_check_equal $out "base-system-1.0_1"
+
+	cd repo
+	xbps-create -A noarch -n xbps-1.1_1 -s "xbps pkg" ../xbps
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -r root --repository=$PWD/repo -yud
+	atf_check_equal $? 0
+
+	out=$(xbps-query -r root -p pkgver xbps)
+	atf_check_equal $out "xbps-1.1_1"
+
+	out=$(xbps-query -r root -p pkgver base-system)
+	atf_check_equal $out "base-system-1.0_1"
+}
+
 atf_init_test_cases() {
 	atf_add_test_case update_xbps
 	atf_add_test_case update_xbps_with_revdeps
+	atf_add_test_case update_xbps_with_uptodate_revdeps
 }


### PR DESCRIPTION
The current code was failing because while checking for updates
on its reverse dependencies, up-to-date versions were treated
as an error.

Added a new test case to verify that it works as expected.

Signed-off-by: Juan RP <xtraeme@gmail.com>