### PR TITLE
xbps-checkvers --format

### DIFF
--- a/bin/xbps-checkvers/main.c
+++ b/bin/xbps-checkvers/main.c
@@ -635,8 +635,7 @@ static void
 rcv_printf(rcv_t *rcv, FILE *fp, const char *pkgname, const char *repover,
     const char *srcver)
 {
-	char tmpl[128], *p;
-	const char *f;
+	const char *f, *p;
 
 	for (f = rcv->format; *f; f++) {
 		if (*f == '\\') {
@@ -661,10 +660,8 @@ rcv_printf(rcv_t *rcv, FILE *fp, const char *pkgname, const char *repover,
 		case 'r': fputs(repover, fp); break;
 		case 's': fputs(srcver, fp); break;
 		case 't':
-			xbps_strlcpy(tmpl, rcv->fname, sizeof tmpl);
-			if ((p = strchr(tmpl, '/')))
-				*p = '\0';
-			fputs(tmpl, fp);
+			p = strchr(rcv->fname, '/');
+			fwrite(rcv->fname, p ? (size_t)(p - rcv->fname) : strlen(rcv->fname), 1, fp);
 			break;
 		}
 	}

--- a/bin/xbps-checkvers/main.c
+++ b/bin/xbps-checkvers/main.c
@@ -413,6 +413,7 @@ rcv_process_file(rcv_t *rcv, const char *fname, rcv_check_func check)
 			goto update;
 		rcv->env = d;
 		rcv->have_vars = GOT_PKGNAME_VAR | GOT_VERSION_VAR | GOT_REVISION_VAR;
+		rcv->fname = fname;
 	} else {
 update:
 		if (!rcv_load_file(rcv, fname)) {

--- a/bin/xbps-checkvers/main.c
+++ b/bin/xbps-checkvers/main.c
@@ -635,6 +635,7 @@ static void
 rcv_printf(rcv_t *rcv, FILE *fp, const char *pkgname, const char *repover,
     const char *srcver)
 {
+	char tmpl[128], *p;
 	const char *f;
 
 	for (f = rcv->format; *f; f++) {
@@ -659,6 +660,12 @@ rcv_printf(rcv_t *rcv, FILE *fp, const char *pkgname, const char *repover,
 		case 'n': fputs(pkgname, fp); break;
 		case 'r': fputs(repover, fp); break;
 		case 's': fputs(srcver, fp); break;
+		case 't':
+			xbps_strlcpy(tmpl, rcv->fname, sizeof tmpl);
+			if ((p = strchr(tmpl, '/')))
+				*p = '\0';
+			fputs(tmpl, fp);
+			break;
 		}
 	}
 	fputc('\n', fp);

--- a/bin/xbps-checkvers/main.c
+++ b/bin/xbps-checkvers/main.c
@@ -479,38 +479,23 @@ rcv_set_distdir(rcv_t *rcv, const char *distdir)
 static bool
 check_reverts(const char *repover, const char *reverts)
 {
-	bool rv = false;
-	char *sreverts, *p;
+	const char *s, *e;
 	size_t len;
 
 	assert(reverts);
-	if (!(len = strlen(reverts)))
+
+	s = reverts;
+	if ((len = strlen(s)) == 0)
 		return false;
 
-	assert((sreverts = strdup(reverts)));
-
-	for (p = sreverts; (p = strstr(p, repover));) {
-		/*
-		 * Check if it's the first character or the previous character is a
-		 * whitespace.
-		 */
-		if (p > sreverts && !isalpha(p[-1]) && !isspace(p[-1])) {
-			p++; // always advance
-			continue;
-		}
-		p += strlen(repover);
-		/*
-		 * Check if it's the last character or if the next character is a
-		 * whitespace
-		 */
-		if (isspace(*p) || *p == '\0') {
-			rv = true;
-			break;
-		}
+	for (s = reverts; s < reverts+len; s = e+1) {
+		if (!(e = strchr(s, ' ')))
+			e = reverts+len;
+		if (strncmp(s, repover, e-s) == 0)
+			return true;
 	}
 
-	free(sreverts);
-	return rv;
+	return false;
 }
 
 static void

--- a/bin/xbps-checkvers/xbps-checkvers.1
+++ b/bin/xbps-checkvers/xbps-checkvers.1
@@ -33,6 +33,33 @@ Specifies a full path to the void-packages repository. By default set to
 .Nm ~/void-packages .
 .It Fl d, Fl -debug
 Enables extra debugging shown to stderr.
+.It Fl f, Fl -format Ar format
+Format according to the string
+.Ar format ,
+inspired by
+.Xr printf 3 .
+.Pp
+The following formatting codes may be used:
+.Bl -tag -width Ds
+.It Cm \en
+Newline.
+.It Cm \et
+Tab.
+.It Cm \e0
+NULL.
+.It Cm \&%%
+A plain
+.Sq Li \&% .
+.It Cm \&%n
+The package name.
+.It Cm \&%r
+The repository version.
+.It Cm \&%s
+The source package version.
+.El
+.Pp
+The default format is
+.Dq Cm "%n %r %s" .
 .It Fl h, Fl -help
 Show the help message.
 .It Fl i, Fl -ignore-conf-repos

--- a/bin/xbps-checkvers/xbps-checkvers.1
+++ b/bin/xbps-checkvers/xbps-checkvers.1
@@ -56,6 +56,8 @@ The package name.
 The repository version.
 .It Cm \&%s
 The source package version.
+.It Cm \&%t
+The requested template name (this can be a sub package).
 .El
 .Pp
 The default format is

--- a/tests/xbps/xbps-checkvers/checkvers.sh
+++ b/tests/xbps/xbps-checkvers/checkvers.sh
@@ -165,7 +165,7 @@ EOF
 	cd ..
 	xbps-checkvers -R $PWD/some_repo -D $PWD/void-packages 2>out
 	atf_check_equal $? 1
-	atf_check_equal "$(cat out)" "ERROR: 'A/template': missing pkgname variable!"
+	atf_check_equal "$(cat out)" "ERROR: 'A/template': missing required variable (pkgname, version or revision)!"
 }
 
 atf_test_case srcpkg_missing_version
@@ -191,7 +191,7 @@ EOF
 	cd ..
 	xbps-checkvers -R $PWD/some_repo -D $PWD/void-packages 2>out
 	atf_check_equal $? 1
-	atf_check_equal "$(cat out)" "ERROR: 'A/template': missing version variable!"
+	atf_check_equal "$(cat out)" "ERROR: 'A/template': missing required variable (pkgname, version or revision)!"
 }
 
 atf_test_case srcpkg_missing_revision
@@ -217,7 +217,7 @@ EOF
 	cd ..
 	xbps-checkvers -R $PWD/some_repo -D $PWD/void-packages 2>out
 	atf_check_equal $? 1
-	atf_check_equal "$(cat out)" "ERROR: 'A/template': missing revision variable!"
+	atf_check_equal "$(cat out)" "ERROR: 'A/template': missing required variable (pkgname, version or revision)!"
 }
 
 atf_test_case srcpkg_missing_pkgver
@@ -243,7 +243,7 @@ EOF
 	cd ..
 	xbps-checkvers -R $PWD/some_repo -D $PWD/void-packages 2>out
 	atf_check_equal $? 1
-	atf_check_equal "$(cat out)" "ERROR: 'A/template': missing pkgname variable!"
+	atf_check_equal "$(cat out)" "ERROR: 'A/template': missing required variable (pkgname, version or revision)!"
 }
 
 atf_test_case srcpkg_missing_pkgverrev
@@ -269,7 +269,7 @@ EOF
 	cd ..
 	xbps-checkvers -R $PWD/some_repo -D $PWD/void-packages 2>out
 	atf_check_equal $? 1
-	atf_check_equal "$(cat out)" "ERROR: 'A/template': missing pkgname variable!"
+	atf_check_equal "$(cat out)" "ERROR: 'A/template': missing required variable (pkgname, version or revision)!"
 }
 
 atf_test_case srcpkg_with_a_ref


### PR DESCRIPTION
from the man page:

```
     -f, --format format
         Format according to the string format, inspired by printf(3).

         The following formatting codes may be used:

         \n      Newline.

         \t      Tab.

         \0      NULL.

         %%      A plain ‘%’.

         %n      The package name.

         %r      The repository version.

         %s      The source package version.

         The default format is “%n %r %s”.
```

The other commit makes it easier to just pass a list of package names, instead of having to construct paths.