### PR TITLE
xbps_binpkg_exists: fix access() on remote packages and avoid malloc

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -328,17 +328,27 @@ xbps_repository_pkg_path(struct xbps_handle *xhp, xbps_dictionary_t pkg_repod)
 bool
 xbps_binpkg_exists(struct xbps_handle *xhp, xbps_dictionary_t pkgd)
 {
-	char *binpkg;
-	bool exists = true;
+	char path[PATH_MAX];
+	const char *pkgver, *arch, *repoloc;
 
-	if ((binpkg = xbps_repository_pkg_path(xhp, pkgd)) == NULL)
-		return false;
+	assert(xhp);
+	assert(xbps_object_type(pkgd) == XBPS_TYPE_DICTIONARY);
 
-	if (access(binpkg, R_OK) == -1)
-		exists = false;
+	if (!xbps_dictionary_get_cstring_nocopy(pkgd,
+	    "pkgver", &pkgver))
+		return NULL;
+	if (!xbps_dictionary_get_cstring_nocopy(pkgd,
+	    "architecture", &arch))
+		return NULL;
+	if (!xbps_dictionary_get_cstring_nocopy(pkgd,
+	    "repository", &repoloc))
+		return NULL;
 
-	free(binpkg);
-	return exists;
+	snprintf(path, sizeof(path), "%s/%s.%s.xbps",
+	    xbps_repository_is_remote(repoloc) ? xhp->cachedir : repoloc,
+	    pkgver, arch);
+
+	return access(path, R_OK) == 0;
 }
 
 bool


### PR DESCRIPTION
Before and after:

```
$ strace -e access xbps-install -un
access("/var/cache/xbps/go-1.12.6_1.x86_64.xbps", R_OK) = -1 ENOENT (No such file or directory)
access("https://alpha.de.repo.voidlinux.org/current/go-1.12.6_1.x86_64.xbps", R_OK) = -1 ENOENT (No such file or directory)
access("/var/cache/xbps/isync-1.3.1_2.x86_64.xbps", R_OK) = -1 ENOENT (No such file or directory)
access("https://alpha.de.repo.voidlinux.org/current/isync-1.3.1_2.x86_64.xbps", R_OK) = -1 ENOENT (No such file or directory)
access("/var/cache/xbps/mupdf-1.15.0_3.x86_64.xbps", R_OK) = -1 ENOENT (No such file or directory)
access("https://alpha.de.repo.voidlinux.org/current/mupdf-1.15.0_3.x86_64.xbps", R_OK) = -1 ENOENT (No such file or directory)
access("/var/cache/xbps/nginx-1.16.0_2.x86_64.xbps", R_OK) = -1 ENOENT (No such file or directory)
access("https://alpha.de.repo.voidlinux.org/current/nginx-1.16.0_2.x86_64.xbps", R_OK) = -1 ENOENT (No such file or directory)
access("/var/cache/xbps/nmap-7.70_5.x86_64.xbps", R_OK) = -1 ENOENT (No such file or directory)
access("https://alpha.de.repo.voidlinux.org/current/nmap-7.70_5.x86_64.xbps", R_OK) = -1 ENOENT (No such file or directory)
go-1.12.6_1 update x86_64 https://alpha.de.repo.voidlinux.org/current 325223946 89230340
isync-1.3.1_2 update x86_64 https://alpha.de.repo.voidlinux.org/current 279051 97156
mupdf-1.15.0_3 update x86_64 https://alpha.de.repo.voidlinux.org/current 71055605 40642780
nginx-1.16.0_2 update x86_64 https://alpha.de.repo.voidlinux.org/current 1155389 408360
nmap-7.70_5 update x86_64 https://alpha.de.repo.voidlinux.org/current 24497891 4598732
+++ exited with 0 +++

$ strace -e access ./bin/xbps-install/xbps-install.static -Mun
access("/var/cache/xbps/apk-tools-2.10.4_2.x86_64.xbps", R_OK) = -1 ENOENT (No such file or directory)
access("/var/cache/xbps/cryptsetup-devel-2.1.0_2.x86_64.xbps", R_OK) = -1 ENOENT (No such file or directory)
access("/var/cache/xbps/go-1.12.6_1.x86_64.xbps", R_OK) = -1 ENOENT (No such file or directory)
access("/var/cache/xbps/isync-1.3.1_2.x86_64.xbps", R_OK) = -1 ENOENT (No such file or directory)
access("/var/cache/xbps/libcryptsetup-2.1.0_2.x86_64.xbps", R_OK) = -1 ENOENT (No such file or directory)
access("/var/cache/xbps/mupdf-1.15.0_3.x86_64.xbps", R_OK) = -1 ENOENT (No such file or directory)
access("/var/cache/xbps/nginx-1.16.0_2.x86_64.xbps", R_OK) = -1 ENOENT (No such file or directory)
access("/var/cache/xbps/nmap-7.70_5.x86_64.xbps", R_OK) = -1 ENOENT (No such file or directory)
access("/var/cache/xbps/opensmtpd-6.4.1p2_2.x86_64.xbps", R_OK) = -1 ENOENT (No such file or directory)
apk-tools-2.10.4_2 update x86_64 https://alpha.de.repo.voidlinux.org/current 252520 99688
cryptsetup-devel-2.1.0_2 update x86_64 https://alpha.de.repo.voidlinux.org/current 67170 14408
go-1.12.6_1 update x86_64 https://alpha.de.repo.voidlinux.org/current 325223946 89230340
isync-1.3.1_2 update x86_64 https://alpha.de.repo.voidlinux.org/current 279051 97156
libcryptsetup-2.1.0_2 update x86_64 https://alpha.de.repo.voidlinux.org/current 363992 142496
mupdf-1.15.0_3 update x86_64 https://alpha.de.repo.voidlinux.org/current 71055605 40642780
nginx-1.16.0_2 update x86_64 https://alpha.de.repo.voidlinux.org/current 1155389 408360
nmap-7.70_5 update x86_64 https://alpha.de.repo.voidlinux.org/current 24497891 4598732
opensmtpd-6.4.1p2_2 update x86_64 https://alpha.de.repo.voidlinux.org/current 837607 235468
+++ exited with 0 +++
```