### PR TITLE
fulldeptree: return a proper error if deps can't be resolved.

### DIFF
--- a/bin/xbps-dgraph/main.c
+++ b/bin/xbps-dgraph/main.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2010-2015 Juan Romero Pardines.
+ * Copyright (c) 2010-2019 Juan Romero Pardines.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -470,6 +470,13 @@ create_dot_graph(struct xbps_handle *xhp,
 		} else {
 			rdeps = xbps_pkgdb_get_pkg_fulldeptree(xhp, pkgver);
 		}
+		if (rdeps == NULL) {
+			if (errno == ENODEV)
+				die("package depends on missing dependencies\n");
+			else
+				die("package dependencies couldn't be resolved (error %d)\n", errno);
+		}
+
 		process_fulldeptree(xhp, f, plistd, rdeps, repomode);
 	} else {
 		/*

--- a/bin/xbps-query/show-deps.c
+++ b/bin/xbps-query/show-deps.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2009-2015 Juan Romero Pardines.
+ * Copyright (c) 2009-2019 Juan Romero Pardines.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -38,7 +38,6 @@ show_pkg_deps(struct xbps_handle *xhp, const char *pkgname, bool repomode, bool 
 {
 	xbps_array_t rdeps;
 	xbps_dictionary_t pkgd;
-	unsigned int cnt;
 
 	if (repomode) {
 		if (((pkgd = xbps_rpool_get_pkg(xhp, pkgname)) == NULL) &&
@@ -46,20 +45,20 @@ show_pkg_deps(struct xbps_handle *xhp, const char *pkgname, bool repomode, bool 
 			return errno;
 	} else {
 		if ((pkgd = xbps_pkgdb_get_pkg(xhp, pkgname)) == NULL)
-			return ENOENT;
+			return errno;
 	}
 	if (full) {
 		if (repomode)
 			rdeps = xbps_rpool_get_pkg_fulldeptree(xhp, pkgname);
 		else
 			rdeps = xbps_pkgdb_get_pkg_fulldeptree(xhp, pkgname);
+
+		if (rdeps == NULL)
+			return errno;
 	} else {
 		rdeps = xbps_dictionary_get(pkgd, "run_depends");
 	}
-	if ((cnt = xbps_array_count(rdeps)) == 0)
-		return ENOENT;
-
-	for (unsigned int i = 0; i < cnt; i++) {
+	for (unsigned int i = 0; i < xbps_array_count(rdeps); i++) {
 		const char *pkgdep;
 		xbps_array_get_cstring_nocopy(rdeps, i, &pkgdep);
 		printf("%s\n", pkgdep);
@@ -79,7 +78,7 @@ show_pkg_revdeps(struct xbps_handle *xhp, const char *pkg, bool repomode)
 		revdeps = xbps_pkgdb_get_pkg_revdeps(xhp, pkg);
 
 	if (revdeps == NULL)
-		return ENOENT;
+		return errno;
 
 	for (unsigned int i = 0; i < xbps_array_count(revdeps); i++) {
 		xbps_array_get_cstring_nocopy(revdeps, i, &pkgdep);

--- a/lib/package_fulldeptree.c
+++ b/lib/package_fulldeptree.c
@@ -156,7 +156,12 @@ ordered_depends(struct xbps_handle *xhp, xbps_dictionary_t pkgd, bool rpool)
 			if (curpkgd == NULL)
 				continue;
 		}
-		assert(curpkgd);
+		if (curpkgd == NULL) {
+			/* package depends on missing dependencies */
+			xbps_dbg_printf(xhp, "%s: missing dependency '%s'\n", pkgver, curdep);
+			errno = ENODEV;
+			return NULL;
+		}
 		if ((curdepname = xbps_pkgpattern_name(curdep)) == NULL)
 			curdepname = xbps_pkg_name(curdep);
 
@@ -212,7 +217,8 @@ xbps_get_pkg_fulldeptree(struct xbps_handle *xhp, const char *pkg, bool rpool)
 		    ((pkgd = xbps_pkgdb_get_virtualpkg(xhp, pkg)) == NULL))
 			return NULL;
 	}
-	(void)ordered_depends(xhp, pkgd, rpool);
+	if (ordered_depends(xhp, pkgd, rpool) == NULL)
+		return NULL;
 
 	return result;
 }

--- a/lib/package_orphans.c
+++ b/lib/package_orphans.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2009-2015 Juan Romero Pardines.
+ * Copyright (c) 2009-2019 Juan Romero Pardines.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -121,6 +121,9 @@ add_orphans:
 		pkgd = xbps_array_get(array, i);
 		xbps_dictionary_get_cstring_nocopy(pkgd, "pkgver", &curpkgver);
 		rdeps = xbps_pkgdb_get_pkg_fulldeptree(xhp, curpkgver);
+		if (rdeps == NULL)
+			return NULL;
+
 		for (unsigned int x = 0; x < xbps_array_count(rdeps); x++) {
 			cnt = 0;
 			xbps_array_get_cstring_nocopy(rdeps, x, &deppkgver);


### PR DESCRIPTION
xbps_get_pkg_fulldeptree() now returns NULL and sets errno to ENODEV
when there are missing dependencies, rather than assert()ing.

Added another test case to check returned error codes.

Signed-off-by: Juan RP <xtraeme@gmail.com>