### PR TITLE
xbps: restore default repodata compression format (gzip/zlib).

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,9 +11,6 @@ xbps-0.54 (???):
  * xbps now supports multiple compression formats for repodata
    and binary packages, including: gzip, bzip2, lz4, xz and zstd. [xtraeme]
 
- * xbps-rindex(1): the default compression format for repository data has
-   been switched to ztd (previously zlib). [xtraeme]
-
  * xbps-create(1): new `--compression` formats: lz4 and zstd, defaults to xz. [xtraeme]
 
  * xbps-rindex(1): added `--compression` option, to mimic xbps-create(1). [xtraeme]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ to handle binary packages and repositories. Some highlights:
  * Supports **multiple local/remote repositories** (HTTP/HTTPS/FTP).
  * **RSA signed remote repositories** (NEW in 0.27).
  * Supports **multiple compression formats** for repositories:
-   zlib, bzip2, lz4, xz, [zstd](https://github.com/facebook/zstd) (default in 0.54).
+   gzip (default), bzip2, lz4, xz, [zstd](https://github.com/facebook/zstd).
  * Supports **multiple compression formats** for binary packages:
    zlib, bzip2, lz4, xz (default), [zstd](https://github.com/facebook/zstd).
  * **SHA256 hashes** for package metadata, files and binary packages.

--- a/bin/xbps-rindex/main.c
+++ b/bin/xbps-rindex/main.c
@@ -43,7 +43,7 @@ usage(bool fail)
 	    " -v --verbose                      Verbose messages\n"
 	    " -V --version                      Show XBPS version\n"
 	    " -C --hashcheck                    Consider file hashes for cleaning up packages\n"
-	    "    --compression <fmt>            Compression format: none, gzip, bzip2, lz4, zstd (default), xz.\n"
+	    "    --compression <fmt>            Compression format: none, gzip (default), bzip2, lz4, zstd, xz.\n"
 	    "    --privkey <key>                Path to the private key for signing\n"
 	    "    --signedby <string>            Signature details, i.e \"name <email>\"\n\n"
 	    "MODE\n"

--- a/bin/xbps-rindex/repoflush.c
+++ b/bin/xbps-rindex/repoflush.c
@@ -59,10 +59,7 @@ repodata_flush(struct xbps_handle *xhp, const char *repodir,
 	ar = archive_write_new();
 	assert(ar);
 
-        if (compression == NULL || strcmp(compression, "zstd") == 0) {
-                archive_write_add_filter_zstd(ar);
-                archive_write_set_options(ar, "compression-level=19");
-        } else if (strcmp(compression, "gzip") == 0) {
+        if (compression == NULL || strcmp(compression, "gzip") == 0) {
                 archive_write_add_filter_gzip(ar);
                 archive_write_set_options(ar, "compression-level=9");
         } else if (strcmp(compression, "bzip2") == 0) {
@@ -73,6 +70,9 @@ repodata_flush(struct xbps_handle *xhp, const char *repodir,
                 archive_write_set_options(ar, "compression-level=9");
         } else if (strcmp(compression, "xz") == 0) {
                 archive_write_add_filter_xz(ar);
+        } else if (strcmp(compression, "zstd") == 0) {
+                archive_write_add_filter_zstd(ar);
+                archive_write_set_options(ar, "compression-level=19");
 	} else if (strcmp(compression, "none") == 0) {
                 /* empty */
         } else {

--- a/bin/xbps-rindex/xbps-rindex.1
+++ b/bin/xbps-rindex/xbps-rindex.1
@@ -1,4 +1,4 @@
-.Dd June 17, 2019
+.Dd June 18, 2019
 .Dt XBPS-RINDEX 1
 .Sh NAME
 .Nm xbps-rindex
@@ -19,7 +19,7 @@ in local repositories.
 Enables extra debugging shown to stderr.
 .It Fl -compression Ar none | gzip | bzip2 | xz | lz4 | zstd
 Set the repodata compression format. If unset, defaults to
-.Ar zstd .
+.Ar gzip .
 .It Fl C -hashcheck
 Check not only for file existence but for the correct file hash while cleaning.
 This flag is only useful with the


### PR DESCRIPTION
Any compression format from that list is supported without
additional changes: gzip, bzip2, lz4, xz, zstd.

This is for repository data and binary packages.

Close #122