### PR TITLE
lib/package_unpack.c: silence gcc false positive

### DIFF
--- a/lib/package_unpack.c
+++ b/lib/package_unpack.c
@@ -84,7 +84,7 @@ unpack_archive(struct xbps_handle *xhp,
 	size_t  instbufsiz = 0, rembufsiz = 0;
 	ssize_t entry_size;
 	const char *entry_pname, *transact, *binpkg_pkgver;
-	char *pkgname, *buf;
+	char *pkgname, *buf = NULL;
 	int ar_rv, rv, error, entry_type, flags;
 	bool preserve, update, file_exists, keep_conf_file;
 	bool skip_extract, force, xucd_stats;


### PR DESCRIPTION
On some systems, something like this happens:

```
package_unpack.c: In function 'xbps_unpack_binary_pkg':
package_unpack.c:375:11: error: 'buf' may be used uninitialized in this function [-Werror=maybe-uninitialized]
      rv = xbps_file_hash_check_dictionary(
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          xhp, binpkg_filesd, "files", buf);
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
package_unpack.c:87:18: note: 'buf' was declared here
  char *pkgname, *buf;
                  ^~~
cc1: all warnings being treated as errors
make[1]: *** [Makefile:74: package_unpack.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/builddir/xbps-0.54/lib'
make: *** [Makefile:15: all] Error 1
=> ERROR: xbps-0.54_1: do_build: '${make_cmd} ${makejobs} ${make_build_args} ${make_build_target}' exited with 2
=> ERROR:   in do_build() at common/build-style/configure.sh:14
```

This is not actually a bug as logically `buf` is always initialized in that place, but gcc doesn't like it anyway.

This will also need backporting into `void-packages`.