### PR TITLE
xbps-install(1): added -I, --ignore-file-conflicts.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,8 @@
 xbps-0.55 (???):
 
+ * xbps-install(1): added `-I --ignore-file-conflicts` to not abort
+   the transaction even if file conflicts were detected. [xtraeme]
+
  * xbps-install(1): return 0 if package is already installed,
    or up-to-date if updating, not EEXIST. EEXIST now is only
    returned if there are file conflicts in transaction. [xtraeme]

--- a/bin/xbps-install/main.c
+++ b/bin/xbps-install/main.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2008-2015 Juan Romero Pardines.
+ * Copyright (c) 2008-2019 Juan Romero Pardines.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -43,27 +43,28 @@ usage(bool fail)
 	fprintf(stdout,
 	    "Usage: xbps-install [OPTIONS] [PKGNAME...]\n\n"
 	    "OPTIONS\n"
-	    " -A --automatic           Set automatic installation mode\n"
-	    " -C --config <dir>        Path to confdir (xbps.d)\n"
-	    " -c --cachedir <dir>      Path to cachedir\n"
-	    " -d --debug               Debug mode shown to stderr\n"
-	    " -f --force               Force package re-installation\n"
-	    "                          If specified twice, all files will be\n"
-	    "                          overwritten.\n"
-	    " -h --help                Print help usage\n"
-	    " -i --ignore-conf-repos   Ignore repositories defined in xbps.d\n"
-	    " -U --unpack-only         Unpack packages in transaction, do not configure them\n"
-	    " -M --memory-sync         Remote repository data is fetched and stored\n"
-	    "                          in memory, ignoring on-disk repodata archives.\n"
-	    " -n --dry-run             Dry-run mode\n"
-	    " -R,--repository=<url>    Add repository to the top of the list.\n"
-	    "                          This option can be specified multiple times.\n"
-	    " -r --rootdir <dir>       Full path to rootdir\n"
-	    " -S --sync                Sync remote repository index\n"
-	    " -u --update              Update target package(s)\n"
-	    " -v --verbose             Verbose messages\n"
-	    " -y --yes                 Assume yes to all questions\n"
-	    " -V --version             Show XBPS version\n");
+	    " -A --automatic             Set automatic installation mode\n"
+	    " -C --config <dir>          Path to confdir (xbps.d)\n"
+	    " -c --cachedir <dir>        Path to cachedir\n"
+	    " -d --debug                 Debug mode shown to stderr\n"
+	    " -f --force                 Force package re-installation\n"
+	    "                            If specified twice, all files will be\n"
+	    "                            overwritten.\n"
+	    " -h --help                  Print help usage\n"
+	    " -i --ignore-conf-repos     Ignore repositories defined in xbps.d\n"
+	    " -I --ignore-file-conflicts Ignore detected file conflicts.\n"
+	    " -U --unpack-only           Unpack packages in transaction, do not configure them\n"
+	    " -M --memory-sync           Remote repository data is fetched and stored\n"
+	    "                            in memory, ignoring on-disk repodata archives.\n"
+	    " -n --dry-run               Dry-run mode\n"
+	    " -R,--repository=<url>      Add repository to the top of the list.\n"
+	    "                            This option can be specified multiple times.\n"
+	    " -r --rootdir <dir>         Full path to rootdir\n"
+	    " -S --sync                  Sync remote repository index\n"
+	    " -u --update                Update target package(s)\n"
+	    " -v --verbose               Verbose messages\n"
+	    " -y --yes                   Assume yes to all questions\n"
+	    " -V --version               Show XBPS version\n");
 	exit(fail ? EXIT_FAILURE : EXIT_SUCCESS);
 }
 
@@ -94,7 +95,7 @@ repo_import_key_cb(struct xbps_repo *repo, void *arg UNUSED, bool *done UNUSED)
 int
 main(int argc, char **argv)
 {
-	const char *shortopts = "AC:c:dfhiMnR:r:SuUVvy";
+	const char *shortopts = "AC:c:dfhIiMnR:r:SuUVvy";
 	const struct option longopts[] = {
 		{ "automatic", no_argument, NULL, 'A' },
 		{ "config", required_argument, NULL, 'C' },
@@ -103,6 +104,7 @@ main(int argc, char **argv)
 		{ "force", no_argument, NULL, 'f' },
 		{ "help", no_argument, NULL, 'h' },
 		{ "ignore-conf-repos", no_argument, NULL, 'i' },
+		{ "ignore-file-conflicts", no_argument, NULL, 'I' },
 		{ "memory-sync", no_argument, NULL, 'M' },
 		{ "dry-run", no_argument, NULL, 'n' },
 		{ "repository", required_argument, NULL, 'R' },
@@ -151,6 +153,9 @@ main(int argc, char **argv)
 		case 'h':
 			usage(false);
 			/* NOTREACHED */
+		case 'I':
+			flags |= XBPS_FLAG_IGNORE_FILE_CONFLICTS;
+			break;
 		case 'i':
 			flags |= XBPS_FLAG_IGNORE_CONF_REPOS;
 			break;

--- a/bin/xbps-install/xbps-install.1
+++ b/bin/xbps-install/xbps-install.1
@@ -1,4 +1,4 @@
-.Dd June 12, 2019
+.Dd June 21, 2019
 .Dt XBPS-INSTALL 1
 .Sh NAME
 .Nm xbps-install
@@ -84,6 +84,8 @@ is specified twice all files will be unpacked, even
 .Em configuration files .
 .It Fl h, Fl -help
 Show the help message.
+.It Fl I, Fl -ignore-file-conflicts
+Ignore detected file conflicts in a transaction.
 .It Fl i, Fl -ignore-conf-repos
 Ignore repositories defined in configuration files.
 Only repositories specified in the command line via

--- a/include/xbps.h.in
+++ b/include/xbps.h.in
@@ -50,7 +50,7 @@
  *
  * This header documents the full API for the XBPS Library.
  */
-#define XBPS_API_VERSION	"20190618"
+#define XBPS_API_VERSION	"20190621"
 
 #ifndef XBPS_VERSION
  #define XBPS_VERSION		"UNSET"
@@ -208,6 +208,13 @@
  * Must be set through the xbps_handle::flags member.
  */
 #define XBPS_FLAG_UNPACK_ONLY 		0x00001000
+
+/**
+ * @def XBPS_FLAG_IGNORE_FILE_CONFLICTS
+ * Continue with transaction even if there are file conflicts.
+ * Must be set through the xbps_handle::flags member.
+ */
+#define XBPS_FLAG_IGNORE_FILE_CONFLICTS	0x00002000
 
 /**
  * @def XBPS_FETCH_CACHECONN

--- a/lib/transaction_files.c
+++ b/lib/transaction_files.c
@@ -460,6 +460,9 @@ collect_file(struct xbps_handle *xhp, const char *file, size_t size,
 			    EEXIST, pkgver,
 			    "%s: file `%s' already installed by package %s.",
 			    pkgver, file, item->new.pkgver);
+			if (xhp->flags & XBPS_FLAG_IGNORE_FILE_CONFLICTS)
+				return 0;
+
 			return EEXIST;
 		}
 		goto add;

--- a/tests/xbps/libxbps/shell/obsoletefiles_test.sh
+++ b/tests/xbps/libxbps/shell/obsoletefiles_test.sh
@@ -563,6 +563,10 @@ conflicting_files_in_transaction_body() {
 	xbps-install -r root -C null.conf --repository=$PWD/some_repo -ydv A B
 	# EEXIST
 	atf_check_equal $? 17
+
+	# ignored file conflicts
+	xbps-install -r root -C null.conf --repository=$PWD/some_repo -Iydv A B
+	atf_check_equal $? 0
 }
 
 atf_test_case obsolete_dir


### PR DESCRIPTION
If set it will continue with the transaction and will
just print what are the conflicting files without returning
EEXIST.

This is a temporary solution for void where there are still
some packages with conflicting files (qt5-host-tools vs qt5-tools-devel).

With input by @duncaen