### PR TITLE
lib/plist.c: fix xbps_array_foreach_cb_multi processing entries multiple times

### DIFF
--- a/lib/plist.c
+++ b/lib/plist.c
@@ -111,11 +111,9 @@ xbps_array_foreach_cb_multi(struct xbps_handle *xhp,
 	if (xbps_object_type(array) != XBPS_TYPE_ARRAY)
 		return 0;
 
-	if (!xbps_array_count(array))
+	arraycount = xbps_array_count(array);
+	if (arraycount == 0)
 		return 0;
-
-	/* - 1 because there's a private dict used internally */
-	arraycount = xbps_array_count(array) - 1;
 
 	maxthreads = (int)sysconf(_SC_NPROCESSORS_ONLN);
 	if (maxthreads <= 1 || arraycount <= 1) /* use single threaded routine */

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -103,7 +103,7 @@ xbps_array_foreach_cb_multi(struct xbps_handle *xhp,
 	struct thread_data *thd;
 	unsigned int arraycount, slicecount;
 	int rv = 0, maxthreads;
-	unsigned int reserved = 0;
+	unsigned int reserved;
 	pthread_spinlock_t reserved_lock;
 
 	assert(fn != NULL);
@@ -137,6 +137,8 @@ xbps_array_foreach_cb_multi(struct xbps_handle *xhp,
 			slicecount = 32;
 		}
 	}
+
+	reserved = slicecount * maxthreads;
 
 	for (int i = 0; i < maxthreads; i++) {
 		thd[i].array = array;


### PR DESCRIPTION
the first thread to finish will start again from 0 (reserved) until 0+slicecount,
next thread will then start from the end of the previous thread which
is already wrong, resulting in processing the first slicecount*maxthreads
entries twice.

The first slicecount*maxthreads entries are accounted by the thread
creation loop and `reserved` has to start at the first unaccounted index.