### PR TITLE
ignorepkg removal

### DIFF
--- a/lib/transaction_revdeps.c
+++ b/lib/transaction_revdeps.c
@@ -137,6 +137,13 @@ xbps_transaction_revdeps(struct xbps_handle *xhp, xbps_array_t pkgs)
 			free(pkgname);
 			continue;
 		}
+		/*
+		 * If pkg is ignored, pass to the next one.
+		 */
+		if (xbps_pkg_is_ignored(xhp, pkgver)) {
+			free(pkgname);
+			continue;
+		}
 		free(pkgname);
 		/*
 		 * Time to validate revdeps for current pkg.

--- a/tests/xbps/libxbps/shell/ignore_test.sh
+++ b/tests/xbps/libxbps/shell/ignore_test.sh
@@ -101,8 +101,40 @@ remove_with_ignored_dep_body() {
 	atf_check_equal $? 2
 }
 
+atf_test_case remove_ignored_dep
+
+remove_ignored_dep_head() {
+	atf_set "descr" "Tests for pkg remove: pkg is dependency but ignored"
+}
+
+remove_ignored_dep_body() {
+	mkdir -p repo root/xbps.d pkg_A pkg_B
+	cd repo
+	xbps-create -A noarch -n A-1.0_1 -s "A pkg" -D "B-1.0_1" ../pkg_A
+	atf_check_equal $? 0
+	xbps-create -A noarch -n B-1.0_1 -s "B pkg" ../pkg_B
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+	xbps-install -r root -C xbps.d --repository=$PWD/repo -yd A
+	atf_check_equal $? 0
+	echo "ignorepkg=B" > root/xbps.d/ignore.conf
+	out=$(xbps-remove -r root -C xbps.d -Rn B)
+	set -- $out
+	exp="$1 $2 $3 $4"
+	atf_check_equal "$exp" "B-1.0_1 remove noarch $PWD/repo"
+	xbps-remove -r root -C xbps.d -Ryvd B
+	atf_check_equal $? 0
+	xbps-query -r root A
+	atf_check_equal $? 0
+	xbps-query -r root B
+	atf_check_equal $? 2
+}
+
 atf_init_test_cases() {
 	atf_add_test_case install_with_ignored_dep
 	atf_add_test_case update_with_ignored_dep
 	atf_add_test_case remove_with_ignored_dep
+	atf_add_test_case remove_ignored_dep
 }


### PR DESCRIPTION
At the moment `ignorepkg` only works on install and update, this change allows users to add a package to the ignored packages after installation and then remove the package with `xbps-remove`.