### PR TITLE
bin/xbps-install: update_pkg return EEXIST if package is up to date

### DIFF
--- a/bin/xbps-install/transaction.c
+++ b/bin/xbps-install/transaction.c
@@ -286,7 +286,7 @@ update_pkg(struct xbps_handle *xhp, const char *pkgname)
 	rv = xbps_transaction_update_pkg(xhp, pkgname);
 	if (rv == EEXIST) {
 		printf("Package '%s' is up to date.\n", pkgname);
-		return 0;
+		return EEXIST;
 	} else if (rv == ENOENT)
 		fprintf(stderr, "Package '%s' not found in "
 		    "repository pool.\n", pkgname);


### PR DESCRIPTION
makes 58509996aabea52ffc40e5e01c9eb00730c6cdcc work for
`xbps-install -u <pkg>`