### PR TITLE
Enable LTO (Link Time Optimization) 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
    - CC=gcc IMG=voidlinux/voidlinux-musl DEPS="gcc musl-devel"
    - CC=clang IMG=voidlinux/voidlinux-musl DEPS="clang musl-devel"
    - CC=tcc IMG=voidlinux/voidlinux-musl DEPS="tcc binutils musl-devel"
+   - CC=pcc IMG=voidlinux/voidlinux-musl DEPS="pcc binutils musl-devel"
 
 install:
  - docker pull "$IMG"

--- a/bin/xbps-alternatives/main.c
+++ b/bin/xbps-alternatives/main.c
@@ -98,7 +98,7 @@ list_pkg_alternatives(xbps_dictionary_t pkgd, const char *group, bool print_key)
 			printf("%s\n", keyname);
 
 		for (unsigned int x = 0; x < xbps_array_count(array); x++) {
-			const char *str;
+			const char *str = NULL;
 
 			xbps_array_get_cstring_nocopy(array, x, &str);
 			printf("  - %s\n", str);
@@ -144,7 +144,7 @@ list_alternatives(struct xbps_handle *xhp, const char *pkgname, const char *grp)
 
 		printf("%s\n", keyname);
 		for (unsigned int x = 0; x < xbps_array_count(array); x++) {
-			const char *str;
+			const char *str = NULL;
 
 			xbps_array_get_cstring_nocopy(array, x, &str);
 			printf(" - %s%s\n", str, x == 0 ? " (current)" : "");

--- a/bin/xbps-create/main.c
+++ b/bin/xbps-create/main.c
@@ -286,7 +286,7 @@ static bool
 entry_is_conf_file(const char *file)
 {
 	xbps_array_t a;
-	const char *curfile;
+	const char *curfile = NULL;
 
 	assert(file);
 

--- a/bin/xbps-dgraph/main.c
+++ b/bin/xbps-dgraph/main.c
@@ -350,7 +350,7 @@ process_fulldeptree(struct xbps_handle *xhp, FILE *f,
 	i = xbps_array_count(rdeps);
 	while (i--) {
 		xbps_dictionary_t rpkgd;
-		const char *pkgdep;
+		const char *pkgdep = NULL;
 		unsigned int pkgidx = 0;
 		bool found = false;
 
@@ -382,7 +382,7 @@ process_fulldeptree(struct xbps_handle *xhp, FILE *f,
 		rpkgrdeps = xbps_dictionary_get(rpkgd, "run_depends");
 		for (x = 0; x < xbps_array_count(rpkgrdeps); x++) {
 			struct pkgdep *ppd;
-			const char *rpkgdep;
+			const char *rpkgdep = NULL;
 
 			xbps_array_get_cstring_nocopy(rpkgrdeps, x, &rpkgdep);
 			SLIST_FOREACH(ppd, &pkgdep_list, pkgdep_entries) {
@@ -406,7 +406,7 @@ process_fulldeptree(struct xbps_handle *xhp, FILE *f,
 	fprintf(f, "\t%u [label=\"%s\",style=\"filled\",fillcolor=\"darksalmon\"];\n", i, pkgver);
 	rpkgrdeps = xbps_dictionary_get(pkgd, "run_depends");
 	for (x = 0; x < xbps_array_count(rpkgrdeps); x++) {
-		const char *rpkgdep;
+		const char *rpkgdep = NULL;
 
 		xbps_array_get_cstring_nocopy(rpkgrdeps, x, &rpkgdep);
 		SLIST_FOREACH(pd, &pkgdep_list, pkgdep_entries) {

--- a/bin/xbps-install/transaction.c
+++ b/bin/xbps-install/transaction.c
@@ -39,7 +39,7 @@
 static void
 print_array(xbps_array_t a)
 {
-	const char *str;
+	const char *str = NULL;
 
 	for (unsigned int i = 0; i < xbps_array_count(a); i++) {
 		xbps_array_get_cstring_nocopy(a, i, &str);

--- a/bin/xbps-pkgdb/check.c
+++ b/bin/xbps-pkgdb/check.c
@@ -42,7 +42,7 @@ pkgdb_cb(struct xbps_handle *xhp UNUSED,
 		void *arg,
 		bool *done UNUSED)
 {
-	const char *pkgver;
+	const char *pkgver = NULL;
 	char *pkgname;
 	int rv, *errors = (int *)arg;
 

--- a/bin/xbps-pkgdb/check_pkg_files.c
+++ b/bin/xbps-pkgdb/check_pkg_files.c
@@ -52,7 +52,7 @@ check_file_mtime(xbps_dictionary_t d, const char *pkg, const char *path)
 {
 	struct stat sb;
 	uint64_t mtime = 0;
-	const char *file;
+	const char *file = NULL;
 
 	/* if obj is not there, skip silently */
 	if (!xbps_dictionary_get_uint64(d, "mtime", &mtime))
@@ -82,7 +82,7 @@ check_pkg_files(struct xbps_handle *xhp, const char *pkgname, void *arg)
 	xbps_object_t obj;
 	xbps_object_iterator_t iter;
 	xbps_dictionary_t pkg_filesd = arg;
-	const char *file, *sha256;
+	const char *file = NULL, *sha256 = NULL;
 	char *path;
 	bool mutable, test_broken = false;
 	int rv = 0, errors = 0;

--- a/bin/xbps-pkgdb/check_pkg_rundeps.c
+++ b/bin/xbps-pkgdb/check_pkg_rundeps.c
@@ -49,7 +49,7 @@ check_pkg_rundeps(struct xbps_handle *xhp, const char *pkgname, void *arg)
 {
 	xbps_dictionary_t pkg_propsd = arg;
 	xbps_array_t array;
-	const char *reqpkg;
+	const char *reqpkg = NULL;
 	int rv = 0;
 
 	if (!xbps_pkg_has_rundeps(pkg_propsd))

--- a/bin/xbps-query/list.c
+++ b/bin/xbps-query/list.c
@@ -45,7 +45,7 @@ list_pkgs_in_dict(struct xbps_handle *xhp UNUSED,
 		  bool *loop_done UNUSED)
 {
 	struct list_pkgver_cb *lpc = arg;
-	const char *pkgver, *short_desc, *state_str;
+	const char *pkgver = NULL, *short_desc = NULL, *state_str = NULL;
 	char tmp[255], *out = NULL;
 	int i, len = 0;
 	pkg_state_t state;
@@ -94,7 +94,7 @@ list_manual_pkgs(struct xbps_handle *xhp UNUSED,
 		 void *arg UNUSED,
 		 bool *loop_done UNUSED)
 {
-	const char *pkgver;
+	const char *pkgver = NULL;
 	bool automatic = false;
 
 	xbps_dictionary_get_bool(obj, "automatic-install", &automatic);
@@ -113,7 +113,7 @@ list_hold_pkgs(struct xbps_handle *xhp UNUSED,
 		void *arg UNUSED,
 		bool *loop_done UNUSED)
 {
-	const char *pkgver;
+	const char *pkgver = NULL;
 
 	if (xbps_dictionary_get(obj, "hold")) {
 		xbps_dictionary_get_cstring_nocopy(obj, "pkgver", &pkgver);
@@ -130,7 +130,7 @@ list_repolock_pkgs(struct xbps_handle *xhp UNUSED,
 		void *arg UNUSED,
 		bool *loop_done UNUSED)
 {
-	const char *pkgver;
+	const char *pkgver = NULL;
 
 	if (xbps_dictionary_get(obj, "repolock")) {
 		xbps_dictionary_get_cstring_nocopy(obj, "pkgver", &pkgver);
@@ -144,7 +144,7 @@ int
 list_orphans(struct xbps_handle *xhp)
 {
 	xbps_array_t orphans;
-	const char *pkgver;
+	const char *pkgver = NULL;
 
 	orphans = xbps_find_pkg_orphans(xhp, NULL);
 	if (orphans == NULL)
@@ -226,7 +226,7 @@ _find_longest_pkgver_cb(struct xbps_handle *xhp UNUSED,
 			bool *loop_done UNUSED)
 {
 	struct fflongest *ffl = arg;
-	const char *pkgver;
+	const char *pkgver = NULL;
 	unsigned int len;
 
 	xbps_dictionary_get_cstring_nocopy(obj, "pkgver", &pkgver);

--- a/bin/xbps-query/ownedby.c
+++ b/bin/xbps-query/ownedby.c
@@ -51,7 +51,7 @@ match_files_by_pattern(xbps_dictionary_t pkg_filesd,
 		       const char *pkgver)
 {
 	xbps_array_t array;
-	const char *keyname, *typestr;
+	const char *keyname = NULL, *typestr = NULL;
 
 	keyname = xbps_dictionary_keysym_cstring_nocopy(key);
 
@@ -104,7 +104,7 @@ ownedby_pkgdb_cb(struct xbps_handle *xhp,
 	xbps_dictionary_t pkgmetad;
 	xbps_array_t files_keys;
 	struct ffdata *ffd = arg;
-	const char *pkgver;
+	const char *pkgver = NULL;
 
 	(void)obj_key;
 	(void)done;
@@ -136,7 +136,7 @@ repo_match_cb(struct xbps_handle *xhp,
 	xbps_dictionary_t filesd;
 	xbps_array_t files_keys;
 	struct ffdata *ffd = arg;
-	const char *pkgver;
+	const char *pkgver = NULL;
 	char *bfile;
 
 	xbps_dictionary_set_cstring_nocopy(obj, "repository", ffd->repouri);

--- a/bin/xbps-query/search.c
+++ b/bin/xbps-query/search.c
@@ -54,7 +54,7 @@ struct search_data {
 static void
 print_results(struct xbps_handle *xhp, struct search_data *sd)
 {
-	const char *pkgver, *desc, *inststr;
+	const char *pkgver = NULL, *desc = NULL, *inststr = NULL;
 	char tmp[256], *out;
 	unsigned int j, tlen = 0, len = 0;
 
@@ -102,7 +102,7 @@ search_array_cb(struct xbps_handle *xhp UNUSED,
 {
 	xbps_object_t obj2;
 	struct search_data *sd = arg;
-	const char *pkgver = NULL, *desc, *str;
+	const char *pkgver = NULL, *desc = NULL, *str = NULL;
 
 	if (!xbps_dictionary_get_cstring_nocopy(obj, "pkgver", &pkgver))
 		return 0;

--- a/bin/xbps-query/show-deps.c
+++ b/bin/xbps-query/show-deps.c
@@ -59,7 +59,7 @@ show_pkg_deps(struct xbps_handle *xhp, const char *pkgname, bool repomode, bool 
 		rdeps = xbps_dictionary_get(pkgd, "run_depends");
 	}
 	for (unsigned int i = 0; i < xbps_array_count(rdeps); i++) {
-		const char *pkgdep;
+		const char *pkgdep = NULL;
 		xbps_array_get_cstring_nocopy(rdeps, i, &pkgdep);
 		printf("%s\n", pkgdep);
 	}
@@ -70,7 +70,7 @@ int
 show_pkg_revdeps(struct xbps_handle *xhp, const char *pkg, bool repomode)
 {
 	xbps_array_t revdeps;
-	const char *pkgdep;
+	const char *pkgdep = NULL;
 
 	if (repomode)
 		revdeps = xbps_rpool_get_pkg_revdeps(xhp, pkg);

--- a/bin/xbps-query/show-info-files.c
+++ b/bin/xbps-query/show-info-files.c
@@ -209,7 +209,7 @@ show_pkg_files(xbps_dictionary_t filesd)
 	xbps_array_t array, allkeys;
 	xbps_object_t obj;
 	xbps_dictionary_keysym_t ksym;
-	const char *keyname, *file;
+	const char *keyname = NULL, *file = NULL;
 
 	if (xbps_object_type(filesd) != XBPS_TYPE_DICTIONARY)
 		return EINVAL;

--- a/bin/xbps-rindex/index-add.c
+++ b/bin/xbps-rindex/index-add.c
@@ -135,7 +135,7 @@ repodata_commit(struct xbps_handle *xhp, const char *repodir,
 
 		pkgshlibs = xbps_dictionary_get(pkg, "shlib-provides");
 		for (unsigned int i = 0; i < xbps_array_count(pkgshlibs); i++) {
-			const char *shlib;
+			const char *shlib = NULL;
 			xbps_array_get_cstring_nocopy(pkgshlibs, i, &shlib);
 			xbps_dictionary_remove(usedshlibs, shlib);
 		}
@@ -152,7 +152,7 @@ repodata_commit(struct xbps_handle *xhp, const char *repodir,
 
 		pkgshlibs = xbps_dictionary_get(pkg, "shlib-provides");
 		for (unsigned int i = 0; i < xbps_array_count(pkgshlibs); i++) {
-			const char *shlib;
+			const char *shlib = NULL;
 			xbps_array_get_cstring_nocopy(pkgshlibs, i, &shlib);
 			xbps_dictionary_remove(usedshlibs, shlib);
 		}
@@ -171,7 +171,7 @@ repodata_commit(struct xbps_handle *xhp, const char *repodir,
 			printf("  %s (provided by: %s; used by: ", shlib, provider);
 			pre = "";
 			for (unsigned int i = 0; i < xbps_array_count(users); i++) {
-				const char *user;
+				const char *user = NULL;
 				xbps_array_get_cstring_nocopy(users, i, &user);
 				xbps_dictionary_remove(usedshlibs, shlib);
 				printf("%s%s",pre, user);
@@ -183,7 +183,7 @@ repodata_commit(struct xbps_handle *xhp, const char *repodir,
 		iter = xbps_dictionary_iterator(stage);
 		while ((keysym = xbps_object_iterator_next(iter))) {
 			xbps_dictionary_t pkg = xbps_dictionary_get_keysym(stage, keysym);
-			const char *pkgver, *arch;
+			const char *pkgver = NULL, *arch = NULL;
 			xbps_dictionary_get_cstring_nocopy(pkg, "pkgver", &pkgver);
 			xbps_dictionary_get_cstring_nocopy(pkg, "architecture", &arch);
 			printf("stage: added `%s' (%s)\n", pkgver, arch);
@@ -197,7 +197,7 @@ repodata_commit(struct xbps_handle *xhp, const char *repodir,
 		while ((keysym = xbps_object_iterator_next(iter))) {
 			const char *pkgname = xbps_dictionary_keysym_cstring_nocopy(keysym);
 			xbps_dictionary_t pkg = xbps_dictionary_get_keysym(stage, keysym);
-			const char *pkgver, *arch;
+			const char *pkgver = NULL, *arch = NULL;
 			xbps_dictionary_get_cstring_nocopy(pkg, "pkgver", &pkgver);
 			xbps_dictionary_get_cstring_nocopy(pkg, "architecture", &arch);
 			printf("index: added `%s' (%s).\n", pkgver, arch);

--- a/bin/xbps-rindex/index-clean.c
+++ b/bin/xbps-rindex/index-clean.c
@@ -53,7 +53,7 @@ idx_cleaner_cb(struct xbps_handle *xhp,
 		bool *done UNUSED)
 {
 	struct CleanerCbInfo *info = arg;
-	const char *arch, *pkgver, *sha256;
+	const char *arch = NULL, *pkgver = NULL, *sha256 = NULL;
 	char *filen, *pkgname;
 
 	xbps_dictionary_get_cstring_nocopy(obj, "architecture", &arch);

--- a/configure
+++ b/configure
@@ -335,6 +335,17 @@ if [ $? -ne 0 ]; then
 	echo "ERRROR: A compatible C99 compiler is required, exiting..."
 	exit 1
 fi
+#
+# Enable LTO if supported (clang and gcc)
+#
+check_compiler_flag lto f CFLAGS
+if [ $? -eq 0 ]; then
+	echo "LDFLAGS += -flto" >> $CONFIG_MK
+	if [ "$CC" = "gcc" ]; then
+		echo "AR = gcc-ar" >> $CONFIG_MK
+		echo "RANLIB = gcc-ranlib" >>$CONFIG_MK
+	fi
+fi
 
 if [ -n "$CFLAGS" ]; then
 	echo "CFLAGS +=	$CFLAGS" >>$CONFIG_MK

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,5 +1,7 @@
 -include ../config.mk
 
+RANLIB ?= ranlib
+
 LIBXBPS_MAJOR = 4
 LIBXBPS_MINOR = 0
 LIBXBPS_MICRO = 0
@@ -84,7 +86,7 @@ libxbps.a: $(LIBFETCH_OBJS) $(LIBPROP_OBJS) $(OBJS)
 	@printf " [AR]\t\t$@\n"
 	${SILENT}$(AR) rcs $@ $^
 	@printf " [RANLIB]\t$@\n"
-	${SILENT}ranlib $@
+	${SILENT}$(RANLIB) $@
 
 .PHONY: install
 install: all

--- a/lib/initend.c
+++ b/lib/initend.c
@@ -43,8 +43,8 @@
 int
 xbps_init(struct xbps_handle *xhp)
 {
-	char *buf;
-	const char *repodir, *native_arch;
+	char *buf = NULL;
+	const char *repodir = NULL, *native_arch = NULL;
 	int rv = 0;
 	size_t size;
 

--- a/lib/package_alternatives.c
+++ b/lib/package_alternatives.c
@@ -232,7 +232,7 @@ xbps_alternatives_set(struct xbps_handle *xhp, const char *pkgname,
 {
 	xbps_array_t allkeys;
 	xbps_dictionary_t alternatives, pkg_alternatives, pkgd, prevpkgd, prevpkg_alts;
-	const char *pkgver, *prevpkgname;
+	const char *pkgver = NULL, *prevpkgname = NULL;
 	int rv = 0;
 
 	assert(xhp);

--- a/lib/package_fulldeptree.c
+++ b/lib/package_fulldeptree.c
@@ -122,7 +122,7 @@ ordered_depends(struct xbps_handle *xhp, xbps_dictionary_t pkgd, bool rpool)
 	xbps_array_t rdeps, provides;
 	xbps_string_t str;
 	struct item *item, *xitem;
-	const char *pkgver;
+	const char *pkgver = NULL;
 	char *pkgn;
 
 	assert(xhp);
@@ -141,7 +141,7 @@ ordered_depends(struct xbps_handle *xhp, xbps_dictionary_t pkgd, bool rpool)
 
 	for (unsigned int i = 0; i < xbps_array_count(rdeps); i++) {
 		xbps_dictionary_t curpkgd;
-		const char *curdep;
+		const char *curdep = NULL;
 		char *curdepname;
 
 		xbps_array_get_cstring_nocopy(rdeps, i, &curdep);

--- a/lib/package_msg.c
+++ b/lib/package_msg.c
@@ -36,7 +36,7 @@ xbps_cb_message(struct xbps_handle *xhp, xbps_dictionary_t pkgd, const char *key
 	xbps_data_t msg;
 	FILE *f = NULL;
 	const void *data = NULL;
-	const char *pkgver;
+	const char *pkgver = NULL;
 	size_t len;
 	char *buf = NULL;
 	int rv = 0;

--- a/lib/package_orphans.c
+++ b/lib/package_orphans.c
@@ -66,7 +66,7 @@ xbps_find_pkg_orphans(struct xbps_handle *xhp, xbps_array_t orphans_user UNUSED)
 	xbps_dictionary_t pkgd, deppkgd;
 	xbps_object_t obj;
 	xbps_object_iterator_t iter;
-	const char *curpkgver, *deppkgver, *reqbydep;
+	const char *curpkgver = NULL, *deppkgver = NULL, *reqbydep = NULL;
 	bool automatic = false;
 	unsigned int i, cnt, reqbycnt;
 

--- a/lib/package_script.c
+++ b/lib/package_script.c
@@ -121,7 +121,7 @@ xbps_pkg_exec_script(struct xbps_handle *xhp,
 	xbps_data_t data;
 	void *buf;
 	size_t buflen;
-	const char *pkgver;
+	const char *pkgver = NULL;
 	int rv;
 
 	assert(xhp);

--- a/lib/pkgdb.c
+++ b/lib/pkgdb.c
@@ -159,8 +159,8 @@ pkgdb_map_vpkgs(struct xbps_handle *xhp)
 	while ((obj = xbps_object_iterator_next(iter))) {
 		xbps_array_t provides;
 		xbps_dictionary_t pkgd;
-		const char *pkgver;
-		char *pkgname;
+		const char *pkgver = NULL;
+		char *pkgname = NULL;
 
 		pkgd = xbps_dictionary_get_keysym(xhp->pkgdb, obj);
 		provides = xbps_dictionary_get(pkgd, "provides");
@@ -172,7 +172,7 @@ pkgdb_map_vpkgs(struct xbps_handle *xhp)
 		assert(pkgname);
 
 		for (unsigned int i = 0; i < xbps_array_count(provides); i++) {
-			const char *vpkg;
+			const char *vpkg = NULL;
 
 			xbps_array_get_cstring_nocopy(provides, i, &vpkg);
 			if (!xbps_dictionary_set_cstring(xhp->vpkgd, vpkg, pkgname)) {
@@ -358,7 +358,7 @@ generate_full_revdeps_tree(struct xbps_handle *xhp)
 	while ((obj = xbps_object_iterator_next(iter))) {
 		xbps_array_t rundeps;
 		xbps_dictionary_t pkgd;
-		const char *pkgver;
+		const char *pkgver = NULL;
 
 		pkgd = xbps_dictionary_get_keysym(xhp->pkgdb, obj);
 		rundeps = xbps_dictionary_get(pkgd, "run_depends");
@@ -368,7 +368,7 @@ generate_full_revdeps_tree(struct xbps_handle *xhp)
 		xbps_dictionary_get_cstring_nocopy(pkgd, "pkgver", &pkgver);
 		for (unsigned int i = 0; i < xbps_array_count(rundeps); i++) {
 			xbps_array_t pkg;
-			const char *pkgdep, *vpkgname;
+			const char *pkgdep = NULL, *vpkgname = NULL;
 			char *curpkgname;
 			bool alloc = false;
 
@@ -403,7 +403,7 @@ xbps_pkgdb_get_pkg_revdeps(struct xbps_handle *xhp, const char *pkg)
 {
 	xbps_array_t res;
 	xbps_dictionary_t pkgd;
-	const char *pkgver;
+	const char *pkgver = NULL;
 	char *pkgname;
 
 	if ((pkgd = xbps_pkgdb_get_pkg(xhp, pkg)) == NULL)
@@ -430,7 +430,7 @@ xbps_dictionary_t
 xbps_pkgdb_get_pkg_files(struct xbps_handle *xhp, const char *pkg)
 {
 	xbps_dictionary_t pkgd, pkgfilesd;
-	const char *pkgver;
+	const char *pkgver = NULL;
 	char *pkgname, *plist;
 
 	if (pkg == NULL)

--- a/lib/plist_find.c
+++ b/lib/plist_find.c
@@ -138,7 +138,7 @@ static xbps_dictionary_t
 match_pkg_by_pkgver(xbps_dictionary_t repod, const char *p)
 {
 	xbps_dictionary_t d = NULL;
-	const char *pkgver;
+	const char *pkgver = NULL;
 	char *pkgname;
 
 	/* exact match by pkgver */
@@ -162,8 +162,8 @@ static xbps_dictionary_t
 match_pkg_by_pattern(xbps_dictionary_t repod, const char *p)
 {
 	xbps_dictionary_t d = NULL;
-	const char *pkgver;
-	char *pkgname;
+	const char *pkgver = NULL;
+	char *pkgname = NULL;
 
 	/* match by pkgpattern in pkgver */
 	if ((pkgname = xbps_pkgpattern_name(p)) == NULL) {

--- a/lib/repo.c
+++ b/lib/repo.c
@@ -454,7 +454,7 @@ revdeps_match(struct xbps_repo *repo, xbps_dictionary_t tpkgd, const char *str)
 	xbps_array_t revdeps = NULL, pkgdeps, provides;
 	xbps_object_iterator_t iter;
 	xbps_object_t obj;
-	const char *pkgver, *tpkgver, *arch, *vpkg;
+	const char *pkgver = NULL, *tpkgver = NULL, *arch = NULL, *vpkg = NULL;
 
 	iter = xbps_dictionary_iterator(repo->idx);
 	assert(iter);

--- a/lib/rpool.c
+++ b/lib/rpool.c
@@ -60,7 +60,7 @@ static SIMPLEQ_HEAD(rpool_head, xbps_repo) rpool_queue =
 int
 xbps_rpool_sync(struct xbps_handle *xhp, const char *uri)
 {
-	const char *repouri;
+	const char *repouri = NULL;
 
 	for (unsigned int i = 0; i < xbps_array_count(xhp->repositories); i++) {
 		xbps_array_get_cstring_nocopy(xhp->repositories, i, &repouri);
@@ -83,7 +83,7 @@ struct xbps_repo HIDDEN *
 xbps_regget_repo(struct xbps_handle *xhp, const char *url)
 {
 	struct xbps_repo *repo;
-	const char *repouri;
+	const char *repouri = NULL;
 
 	if (SIMPLEQ_EMPTY(&rpool_queue)) {
 		/* iterate until we have a match */
@@ -137,8 +137,8 @@ xbps_rpool_foreach(struct xbps_handle *xhp,
 	int (*fn)(struct xbps_repo *, void *, bool *),
 	void *arg)
 {
-	struct xbps_repo *repo;
-	const char *repouri;
+	struct xbps_repo *repo = NULL;
+	const char *repouri = NULL;
 	int rv = 0;
 	bool foundrepo = false, done = false;
 	unsigned int n = 0;
@@ -204,7 +204,7 @@ find_pkg_revdeps_cb(struct xbps_repo *repo, void *arg, bool *done UNUSED)
 {
 	struct rpool_fpkg *rpf = arg;
 	xbps_array_t revdeps = NULL;
-	const char *pkgver;
+	const char *pkgver = NULL;
 
 	revdeps = xbps_repo_get_pkg_revdeps(repo, rpf->pattern);
 	if (xbps_array_count(revdeps)) {
@@ -225,7 +225,7 @@ find_best_pkg_cb(struct xbps_repo *repo, void *arg, bool *done UNUSED)
 {
 	struct rpool_fpkg *rpf = arg;
 	xbps_dictionary_t pkgd;
-	const char *repopkgver;
+	const char *repopkgver = NULL;
 
 	pkgd = xbps_repo_get_pkg(repo, rpf->pattern);
 	if (pkgd == NULL) {

--- a/lib/transaction_files.c
+++ b/lib/transaction_files.c
@@ -388,7 +388,7 @@ static int
 collect_file(struct xbps_handle *xhp, const char *file, size_t size,
 		const char *pkgname, const char *pkgver, unsigned int idx,
 		const char *sha256, enum type type, bool update, bool preserve,
-		bool remove)
+		bool removefile)
 {
 	struct item *item;
 
@@ -402,7 +402,7 @@ collect_file(struct xbps_handle *xhp, const char *file, size_t size,
 		goto add;
 	}
 
-	if (remove) {
+	if (removefile) {
 		if (item->old.type == 0) {
 			/*
 			 * File wasn't removed before.
@@ -471,7 +471,7 @@ collect_file(struct xbps_handle *xhp, const char *file, size_t size,
 
 	return 0;
 add:
-	if (remove) {
+	if (removefile) {
 		item->old.pkgname = strdup(pkgname);
 		item->old.pkgver = strdup(pkgver);
 		item->old.type = type;
@@ -496,7 +496,7 @@ add:
 		 * and installed by another package.
 		 */
 		if (strcmp(item->new.pkgname, item->old.pkgname) != 0) {
-			if (remove) {
+			if (removefile) {
 				xbps_dbg_printf(xhp, "[files] %s: %s moved to"
 				    " package `%s': %s\n", pkgver, typestr(item->old.type),
 				    item->new.pkgver, file);
@@ -514,7 +514,7 @@ add:
 static int
 collect_files(struct xbps_handle *xhp, xbps_dictionary_t d,
 			const char *pkgname, const char *pkgver, unsigned int idx,
-			bool update, bool preserve, bool remove)
+			bool update, bool preserve, bool removefile)
 {
 	xbps_array_t a;
 	xbps_dictionary_t filed;
@@ -528,12 +528,12 @@ collect_files(struct xbps_handle *xhp, xbps_dictionary_t d,
 		for (i = 0; i < xbps_array_count(a); i++) {
 			filed = xbps_array_get(a, i);
 			xbps_dictionary_get_cstring_nocopy(filed, "file", &file);
-			if (remove)
+			if (removefile)
 				xbps_dictionary_get_cstring_nocopy(filed, "sha256", &sha256);
 			size = 0;
 			xbps_dictionary_get_uint64(filed, "size", &size);
 			rv = collect_file(xhp, file, size, pkgname, pkgver, idx, sha256,
-			    TYPE_FILE, update, preserve, remove);
+			    TYPE_FILE, update, preserve, removefile);
 			if (rv == EEXIST) {
 				error = true;
 				continue;
@@ -548,7 +548,7 @@ collect_files(struct xbps_handle *xhp, xbps_dictionary_t d,
 			xbps_dictionary_get_cstring_nocopy(filed, "file", &file);
 			size = 0;
 			xbps_dictionary_get_uint64(filed, "size", &size);
-			if (remove)
+			if (removefile)
 				xbps_dictionary_get_cstring_nocopy(filed, "sha256", &sha256);
 #if 0
 			/* XXX: how to handle conf_file size */
@@ -556,7 +556,7 @@ collect_files(struct xbps_handle *xhp, xbps_dictionary_t d,
 				size = 0;
 #endif
 			rv = collect_file(xhp, file, size, pkgname, pkgver, idx, sha256,
-			    TYPE_FILE, update, preserve, remove);
+			    TYPE_FILE, update, preserve, removefile);
 			if (rv == EEXIST) {
 				error = true;
 				continue;
@@ -570,7 +570,7 @@ collect_files(struct xbps_handle *xhp, xbps_dictionary_t d,
 			filed = xbps_array_get(a, i);
 			xbps_dictionary_get_cstring_nocopy(filed, "file", &file);
 			rv = collect_file(xhp, file, 0, pkgname, pkgver, idx, NULL,
-			    TYPE_LINK, update, preserve, remove);
+			    TYPE_LINK, update, preserve, removefile);
 			if (rv == EEXIST) {
 				error = true;
 				continue;
@@ -584,7 +584,7 @@ collect_files(struct xbps_handle *xhp, xbps_dictionary_t d,
 			filed = xbps_array_get(a, i);
 			xbps_dictionary_get_cstring_nocopy(filed, "file", &file);
 			rv = collect_file(xhp, file, 0, pkgname, pkgver, idx, NULL,
-			    TYPE_DIR, update, preserve, remove);
+			    TYPE_DIR, update, preserve, removefile);
 			if (rv == EEXIST) {
 				error = true;
 				continue;

--- a/lib/transaction_ops.c
+++ b/lib/transaction_ops.c
@@ -257,7 +257,7 @@ xbps_autoupdate(struct xbps_handle *xhp)
 		/* a new xbps version is available, check its revdeps */
 		rdeps = xbps_pkgdb_get_pkg_revdeps(xhp, "xbps");
 		for (unsigned int i = 0; i < xbps_array_count(rdeps); i++)  {
-			const char *curpkgver;
+			const char *curpkgver = NULL;
 			char *curpkgn;
 
 			xbps_array_get_cstring_nocopy(rdeps, i, &curpkgver);
@@ -361,7 +361,7 @@ xbps_transaction_update_pkg(struct xbps_handle *xhp, const char *pkg)
 
 	rdeps = xbps_pkgdb_get_pkg_revdeps(xhp, pkg);
 	for (unsigned int i = 0; i < xbps_array_count(rdeps); i++)  {
-		const char *curpkgver;
+		const char *curpkgver = NULL;
 		char *curpkgn;
 
 		xbps_array_get_cstring_nocopy(rdeps, i, &curpkgver);
@@ -400,7 +400,7 @@ xbps_transaction_install_pkg(struct xbps_handle *xhp, const char *pkg,
 
 	rdeps = xbps_pkgdb_get_pkg_revdeps(xhp, pkg);
 	for (unsigned int i = 0; i < xbps_array_count(rdeps); i++)  {
-		const char *curpkgver;
+		const char *curpkgver = NULL;
 		char *curpkgn;
 
 		xbps_array_get_cstring_nocopy(rdeps, i, &curpkgver);

--- a/lib/transaction_prepare.c
+++ b/lib/transaction_prepare.c
@@ -321,7 +321,7 @@ xbps_transaction_prepare(struct xbps_handle *xhp)
 	}
 	/* ... remove dup edges at head */
 	for (i = 0; i < xbps_array_count(edges); i++) {
-		const char *pkgver;
+		const char *pkgver = NULL;
 		xbps_array_get_cstring_nocopy(edges, i, &pkgver);
 		xbps_remove_pkg_from_array_by_pkgver(pkgs, pkgver);
 	}

--- a/lib/transaction_revdeps.c
+++ b/lib/transaction_revdeps.c
@@ -151,7 +151,7 @@ xbps_transaction_revdeps(struct xbps_handle *xhp, xbps_array_t pkgs)
 		for (unsigned int x = 0; x < xbps_array_count(pkgrdeps); x++) {
 			xbps_array_t rundeps;
 			xbps_dictionary_t revpkgd;
-			const char *curpkgver, *revpkgver, *curdep, *curtract;
+			const char *curpkgver = NULL, *revpkgver, *curdep = NULL, *curtract;
 			char *curpkgname, *curdepname;
 			bool found = false;
 

--- a/lib/transaction_shlibs.c
+++ b/lib/transaction_shlibs.c
@@ -120,7 +120,7 @@ collect_shlibs(struct xbps_handle *xhp, xbps_array_t pkgs, bool req)
 			continue;
 
 		for (unsigned int i = 0; i < xbps_array_count(shobjs); i++) {
-			const char *shlib;
+			const char *shlib = NULL;
 
 			xbps_array_get_cstring_nocopy(shobjs, i, &shlib);
 			xbps_dbg_printf(xhp, "%s: registering %s for %s\n",
@@ -153,7 +153,7 @@ xbps_transaction_shlibs(struct xbps_handle *xhp, xbps_array_t pkgs, xbps_array_t
 
 	while ((obj = xbps_object_iterator_next(iter))) {
 		xbps_array_t array;
-		const char *pkgver, *shlib;
+		const char *pkgver = NULL, *shlib = NULL;
 		char *buf;
 
 		shlib = xbps_dictionary_keysym_cstring_nocopy(obj);

--- a/lib/util.c
+++ b/lib/util.c
@@ -411,6 +411,9 @@ xbps_xasprintf(const char *fmt, ...)
 int
 xbps_pkgpattern_match(const char *pkg, const char *pattern)
 {
+	assert(pkg);
+	assert(pattern);
+
 	/* simple match on "pkg" against "pattern" */
 	if (strcmp(pattern, pkg) == 0)
 		return 1;
@@ -462,7 +465,7 @@ xbps_pkg_reverts(xbps_dictionary_t pkg, const char *pkgver)
 	unsigned int i;
 	xbps_array_t reverts;
 	const char *version = xbps_pkg_version(pkgver);
-	const char *revertver;
+	const char *revertver = NULL;
 
 	if ((reverts = xbps_dictionary_get(pkg, "reverts")) == NULL)
 		return false;


### PR DESCRIPTION
- Fixed all warnings detected by LTO (maybe-uninitialized)
- Added pcc/musl to the build matrix, seems to work now.
