### PR TITLE
Fulldeptree fixups

### DIFF
--- a/lib/package_orphans.c
+++ b/lib/package_orphans.c
@@ -60,7 +60,7 @@
  */
 
 xbps_array_t
-xbps_find_pkg_orphans(struct xbps_handle *xhp, xbps_array_t orphans_user UNUSED)
+xbps_find_pkg_orphans(struct xbps_handle *xhp, xbps_array_t orphans_user)
 {
 	xbps_array_t rdeps, reqby, array = NULL;
 	xbps_dictionary_t pkgd, deppkgd;

--- a/tests/xbps/libxbps/find_pkg_orphans/main.c
+++ b/tests/xbps/libxbps/find_pkg_orphans/main.c
@@ -43,6 +43,7 @@ static const char expected_output[] =
 	"xbps-triggers-1.0_1\n";
 
 static const char expected_output_all[] =
+	"orphan2-0_1\n"
 	"unexistent-pkg-0_1\n"
 	"orphan1-0_1\n"
 	"orphan0-0_1\n";

--- a/tests/xbps/libxbps/find_pkg_orphans/pkgdb-0.38.plist
+++ b/tests/xbps/libxbps/find_pkg_orphans/pkgdb-0.38.plist
@@ -198,6 +198,23 @@
 		<true/>
 		<key>pkgver</key>
 		<string>orphan1-0_1</string>
+		<key>run_depends</key>
+		<array>
+			<string>orphan0&gt;=0_1</string>
+		</array>
+		<key>state</key>
+		<string>installed</string>
+	</dict>
+	<key>orphan2</key>
+	<dict>
+		<key>automatic-install</key>
+		<true/>
+		<key>pkgver</key>
+		<string>orphan2-0_1</string>
+		<key>run_depends</key>
+		<array>
+			<string>orphan0&gt;=0_1</string>
+		</array>
 		<key>state</key>
 		<string>installed</string>
 	</dict>

--- a/tests/xbps/libxbps/shell/incorrect_deps_test.sh
+++ b/tests/xbps/libxbps/shell/incorrect_deps_test.sh
@@ -93,8 +93,8 @@ incorrect_dep_dups_body() {
 
 	out=$(xbps-query -C empty.conf -r root --fulldeptree -x B)
 	set -- $out
-	atf_check_equal $# 2
-	atf_check_equal "$1 $2" "B-1.0_1 A-1.0_1"
+	atf_check_equal $# 1
+	atf_check_equal "$1" "A-1.0_1"
 }
 
 atf_test_case missing_deps


### PR DESCRIPTION
This fixes and adds a test case for an issue we are currently experiencing, where orphaned are not correctly removed, if there are more than one package depending on the same package.

The main issue is that `xbps_get_pkg_fulldeptree` only finds each dep it encounters once, adding the deps to the hashtable, but then never again adding them to any results.
So if `xbps_get_pkg_fulldeptree` is called multiple times and the requested packages share dependencies in their fulldeptree, there are going to be packages missing from the results array.

Another small thing I fixed is to not add the requested package itself to the results:
```
$ xbps-query --fulldeptree -Rx linux4.19
linux4.19-4.19.56_1
```