### PR TITLE
smart revdep updates

### DIFF
--- a/include/xbps_api_impl.h
+++ b/include/xbps_api_impl.h
@@ -127,7 +127,7 @@ xbps_dictionary_t HIDDEN xbps_find_pkg_in_array(xbps_array_t, const char *,
 		const char *);
 xbps_dictionary_t HIDDEN xbps_find_virtualpkg_in_array(struct xbps_handle *,
 		xbps_array_t, const char *, const char *);
-void HIDDEN xbps_transaction_revdeps(struct xbps_handle *, xbps_array_t);
+int HIDDEN xbps_transaction_revdeps(struct xbps_handle *, xbps_array_t);
 bool HIDDEN xbps_transaction_shlibs(struct xbps_handle *, xbps_array_t,
 		xbps_array_t);
 int HIDDEN xbps_transaction_init(struct xbps_handle *);

--- a/lib/transaction_ops.c
+++ b/lib/transaction_ops.c
@@ -342,7 +342,6 @@ xbps_transaction_update_packages(struct xbps_handle *xhp)
 int
 xbps_transaction_update_pkg(struct xbps_handle *xhp, const char *pkg)
 {
-	xbps_array_t rdeps;
 	int rv;
 
 	rv = xbps_autoupdate(xhp);
@@ -359,20 +358,6 @@ xbps_transaction_update_pkg(struct xbps_handle *xhp, const char *pkg)
 		break;
 	}
 
-	rdeps = xbps_pkgdb_get_pkg_revdeps(xhp, pkg);
-	for (unsigned int i = 0; i < xbps_array_count(rdeps); i++)  {
-		const char *curpkgver = NULL;
-		char *curpkgn;
-
-		xbps_array_get_cstring_nocopy(rdeps, i, &curpkgver);
-		curpkgn = xbps_pkg_name(curpkgver);
-		assert(curpkgn);
-		rv = trans_find_pkg(xhp, curpkgn, false, false);
-		free(curpkgn);
-		xbps_dbg_printf(xhp, "%s: trans_find_pkg %s: %d\n", __func__, curpkgver, rv);
-		if (rv && rv != ENOENT && rv != EEXIST && rv != ENODEV)
-			return rv;
-	}
 	rv = trans_find_pkg(xhp, pkg, false, false);
 	xbps_dbg_printf(xhp, "%s: trans_find_pkg %s: %d\n", __func__, pkg, rv);
 	return rv;
@@ -382,7 +367,6 @@ int
 xbps_transaction_install_pkg(struct xbps_handle *xhp, const char *pkg,
 			     bool reinstall)
 {
-	xbps_array_t rdeps;
 	int rv;
 
 	rv = xbps_autoupdate(xhp);
@@ -398,20 +382,6 @@ xbps_transaction_install_pkg(struct xbps_handle *xhp, const char *pkg,
 		break;
 	}
 
-	rdeps = xbps_pkgdb_get_pkg_revdeps(xhp, pkg);
-	for (unsigned int i = 0; i < xbps_array_count(rdeps); i++)  {
-		const char *curpkgver = NULL;
-		char *curpkgn;
-
-		xbps_array_get_cstring_nocopy(rdeps, i, &curpkgver);
-		curpkgn = xbps_pkg_name(curpkgver);
-		assert(curpkgn);
-		rv = trans_find_pkg(xhp, curpkgn, false, false);
-		free(curpkgn);
-		xbps_dbg_printf(xhp, "%s: trans_find_pkg %s: %d\n", __func__, curpkgver, rv);
-		if (rv && rv != ENOENT && rv != EEXIST && rv != ENODEV)
-			return rv;
-	}
 	rv = trans_find_pkg(xhp, pkg, reinstall, false);
 	xbps_dbg_printf(xhp, "%s: trans_find_pkg %s: %d\n", __func__, pkg, rv);
 	return rv;

--- a/tests/xbps/libxbps/shell/install_test.sh
+++ b/tests/xbps/libxbps/shell/install_test.sh
@@ -305,12 +305,14 @@ install_and_update_revdeps_body() {
 	atf_check_equal $? 0
 	xbps-create -A noarch -n C-1.0_1 -s "C pkg" --dependencies "B-1.0_1" ../pkg
 	atf_check_equal $? 0
+	xbps-create -A noarch -n D-1.0_1 -s "D pkg" --dependencies "C>=1.0_1" ../pkg
+	atf_check_equal $? 0
 
 	xbps-rindex -d -a $PWD/*.xbps
 	atf_check_equal $? 0
 
 	cd ..
-	xbps-install -r root --repository=repo -yvd C
+	xbps-install -r root --repository=repo -yvd C D
 	atf_check_equal $? 0
 	atf_check_equal $(xbps-query -r root -p pkgver A) A-1.0_1
 	atf_check_equal $(xbps-query -r root -p pkgver B) B-1.0_1
@@ -321,19 +323,20 @@ install_and_update_revdeps_body() {
 	atf_check_equal $? 0
 	xbps-create -A noarch -n B-1.0_2 -s "B pkg" --dependencies "A-1.0_2" ../pkg
 	atf_check_equal $? 0
-	xbps-create -A noarch -n C-1.0_2 -s "C pkg" --dependencies "B-1.0_2" ../pkg
+	xbps-create -A noarch -n C-1.0_2 -s "C pkg" --dependencies "A-1.0_2" ../pkg
 	atf_check_equal $? 0
-	xbps-create -A noarch -n D-1.0_1 -s "D pkg" --dependencies "C-1.0_2" ../pkg
+	xbps-create -A noarch -n E-1.0_1 -s "E pkg" --dependencies "C-1.0_2" ../pkg
 	atf_check_equal $? 0
 	xbps-rindex -d -a $PWD/*.xbps
 	atf_check_equal $? 0
 	cd ..
-	xbps-install -r root --repository=repo -yvd D
+	xbps-install -r root --repository=repo -yvd E
 	atf_check_equal $? 0
 	atf_check_equal $(xbps-query -r root -p pkgver A) A-1.0_2
 	atf_check_equal $(xbps-query -r root -p pkgver B) B-1.0_2
 	atf_check_equal $(xbps-query -r root -p pkgver C) C-1.0_2
 	atf_check_equal $(xbps-query -r root -p pkgver D) D-1.0_1
+	atf_check_equal $(xbps-query -r root -p pkgver E) E-1.0_1
 }
 
 atf_test_case update_file_timestamps


### PR DESCRIPTION
This patchset removes revdep updates from `xbps_transaction_update_pkg` and `xbps_transaction_install_pkg` and uses the `xbps_transaction_revdeps` function to add required revdep updates to the transaction.
This will make xbps only update revdeps on install/update if the update is really required.

From commit message:
`xbps_transaction_revdeps` will now try to add updates for packages to the
transaction if the dependency is not satisified anymore due to a package
install/update.

`xbps_transaction_prepare` will now check the return value of
`xbps_transaction_revdeps` and repeat the dependency resolution,
until `xbps_transaction_revdeps` returns 0, which means that it didn't
add any new packages to the transaction.