### PR TITLE
Prepare 0.57

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,24 @@
 xbps-0.57 (???):
 
+ * xbps now builds with tcc. [xtraeme]
+
+ * xbps now uses the transactional file checks for package removals,
+   this fixes issues where xbps removes wrong files, if a package
+   replaces another packages with the same files. [duncaen]
+
+ * xbps-remove(1): skip the transaction if no packages are found.
+   This restores the behaviour of xbps prior to 0.54. [xtraeme]
+
+ * xbps-remove(1): fix `-o, --remove-orphans` not removing
+   all orphaned packages. [duncaen]
+
+ * xbps-install(1): if specified packages with `-u, --update` are
+   up to date return EEXIST. [jnbr]
+
+ * xbps-query(1): restores old behaviour of `--fulldeptree`,
+   to not list the package itself. [duncaen]
+
+ * Updated zsh completions. [leah2]
 
 xbps-0.56 (2019-06-24):
 

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,6 @@
 xbps-0.57 (???):
 
- * xbps now builds with tcc. [xtraeme]
+ * xbps now builds with tcc and pcc. [xtraeme]
 
  * xbps now uses the transactional file checks for package removals,
    this fixes issues where xbps removes wrong files, if a package

--- a/bin/xbps-checkvers/main.c
+++ b/bin/xbps-checkvers/main.c
@@ -706,6 +706,17 @@ main(int argc, char **argv)
 	 */
 	if (rcv.distdir == NULL)
 		rcv.distdir = xbps_xasprintf("%s/void-packages", getenv("HOME"));
+
+	{
+		char *tmp = rcv.distdir;
+		rcv.distdir = realpath(tmp, NULL);
+		if (rcv.distdir == NULL) {
+			fprintf(stderr, "Error: realpath(%s): %s\n", tmp, strerror(errno));
+			exit(1);
+		}
+		free(tmp);
+	}
+
 	rcv.cachefile = xbps_xasprintf("%s/.xbps-checkvers.plist", rcv.distdir);
 
 	argc -= optind;

--- a/include/xbps_api_impl.h
+++ b/include/xbps_api_impl.h
@@ -127,7 +127,7 @@ xbps_dictionary_t HIDDEN xbps_find_pkg_in_array(xbps_array_t, const char *,
 		const char *);
 xbps_dictionary_t HIDDEN xbps_find_virtualpkg_in_array(struct xbps_handle *,
 		xbps_array_t, const char *, const char *);
-int HIDDEN xbps_transaction_revdeps(struct xbps_handle *, xbps_array_t);
+void HIDDEN xbps_transaction_revdeps(struct xbps_handle *, xbps_array_t);
 bool HIDDEN xbps_transaction_shlibs(struct xbps_handle *, xbps_array_t,
 		xbps_array_t);
 int HIDDEN xbps_transaction_init(struct xbps_handle *);

--- a/lib/conf.c
+++ b/lib/conf.c
@@ -225,7 +225,7 @@ parse_files_glob(struct xbps_handle *xhp, xbps_dictionary_t seen,
 {
 	char tmppath[PATH_MAX];
 	glob_t globbuf;
-	int rs, rv = 0;
+	int rs, rv = 0, rv2;
 
 	rs = snprintf(tmppath, PATH_MAX, "%s/%s",
 	    pat[0] == '/' ? xhp->rootdir : cwd, pat);
@@ -247,8 +247,8 @@ parse_files_glob(struct xbps_handle *xhp, xbps_dictionary_t seen,
 				continue;
 			xbps_dictionary_set_bool(seen, fname, true);
 		}
-		if ((rv = parse_file(xhp, globbuf.gl_pathv[i], nested)) != 0)
-			break;
+		if ((rv2 = parse_file(xhp, globbuf.gl_pathv[i], nested)) != 0)
+			rv = rv2;
 	}
 	globfree(&globbuf);
 
@@ -268,7 +268,7 @@ parse_file(struct xbps_handle *xhp, const char *path, bool nested)
 
 	if ((fp = fopen(path, "r")) == NULL) {
 		rv = errno;
-		xbps_dbg_printf(xhp, "cannot read configuration file %s: %s\n", path, strerror(rv));
+		xbps_error_printf("cannot read configuration file %s: %s\n", path, strerror(rv));
 		return rv;
 	}
 

--- a/lib/package_remove.c
+++ b/lib/package_remove.c
@@ -110,7 +110,7 @@ int HIDDEN
 xbps_remove_pkg(struct xbps_handle *xhp, const char *pkgver, bool update)
 {
 	xbps_dictionary_t pkgd = NULL, obsd = NULL;
-	xbps_array_t obsoletes;
+	xbps_array_t obsoletes = NULL;
 	char *pkgname, metafile[PATH_MAX];
 	int rv = 0;
 	pkg_state_t state = 0;

--- a/lib/package_remove.c
+++ b/lib/package_remove.c
@@ -43,7 +43,7 @@ check_remove_pkg_files(struct xbps_handle *xhp,
 	bool fail = false;
 
 	if (euid == 0)
-		return true;
+		return false;
 
 	for (unsigned int i = 0; i < xbps_array_count(obsoletes); i++) {
 		const char *file = NULL;

--- a/lib/package_remove.c
+++ b/lib/package_remove.c
@@ -37,264 +37,71 @@
 
 static bool
 check_remove_pkg_files(struct xbps_handle *xhp,
-	xbps_dictionary_t pkgd, const char *pkgver, uid_t euid)
+	xbps_array_t obsoletes, const char *pkgver, uid_t euid)
 {
 	struct stat st;
-	xbps_array_t array;
-	xbps_object_iterator_t iter;
-	xbps_object_t obj;
-	const char *objs[] = { "files", "conf_files", "links", "dirs" };
-	const char *file;
-	char path[PATH_MAX];
 	bool fail = false;
 
-	for (uint8_t i = 0; i < __arraycount(objs); i++) {
-		array = xbps_dictionary_get(pkgd, objs[i]);
-		if (array == NULL || xbps_array_count(array) == 0)
-			continue;
+	if (euid == 0)
+		return true;
 
-		iter = xbps_array_iter_from_dict(pkgd, objs[i]);
-		if (iter == NULL)
+	for (unsigned int i = 0; i < xbps_array_count(obsoletes); i++) {
+		const char *file = NULL;
+		xbps_array_get_cstring_nocopy(obsoletes, i, &file);
+		/*
+		 * Check if effective user ID owns the file; this is
+		 * enough to ensure the user has write permissions
+		 * on the directory.
+		 */
+		if (lstat(file, &st) == 0 && euid == st.st_uid) {
+			/* success */
 			continue;
-
-		while ((obj = xbps_object_iterator_next(iter))) {
-			xbps_dictionary_get_cstring_nocopy(obj, "file", &file);
-			snprintf(path, sizeof(path), "%s/%s", xhp->rootdir, file);
-			/*
-			 * Check if effective user ID owns the file; this is
-			 * enough to ensure the user has write permissions
-			 * on the directory.
-			 */
-			if (euid == 0 || (!lstat(path, &st) && euid == st.st_uid)) {
-				/* success */
-				continue;
-			}
-			if (errno != ENOENT) {
-				/*
-				 * only bail out if something else than ENOENT
-				 * is returned.
-				 */
-				int rv = errno;
-				if (rv == 0) {
-					/* lstat succeeds but euid != uid */
-					rv = EPERM;
-				}
-				fail = true;
-				xbps_set_cb_state(xhp, XBPS_STATE_REMOVE_FILE_FAIL,
-				    rv, pkgver,
-				    "%s: cannot remove `%s': %s",
-				    pkgver, file, strerror(rv));
-			}
-			errno = 0;
 		}
-		xbps_object_iterator_release(iter);
+		if (errno != ENOENT) {
+			/*
+			 * only bail out if something else than ENOENT
+			 * is returned.
+			 */
+			int rv = errno;
+			if (rv == 0) {
+				/* lstat succeeds but euid != uid */
+				rv = EPERM;
+			}
+			fail = true;
+			xbps_set_cb_state(xhp, XBPS_STATE_REMOVE_FILE_FAIL,
+				rv, pkgver,
+				"%s: cannot remove `%s': %s",
+				pkgver, file, strerror(rv));
+		}
+		errno = 0;
 	}
-
 	return fail;
-}
-
-struct order_length_t {
-	unsigned int pos;
-	size_t len;
-};
-
-static int cmp_order_length(const void *l1, const void *l2) {
-	size_t a = ((const struct order_length_t*)l1)->len;
-	size_t b = ((const struct order_length_t*)l2)->len;
-	return (a < b) - (b < a);
 }
 
 static int
 remove_pkg_files(struct xbps_handle *xhp,
-		 xbps_dictionary_t dict,
-		 const char *key,
+		 xbps_array_t obsoletes,
 		 const char *pkgver)
 {
-	xbps_array_t array, dirs;
-	xbps_object_iterator_t iter;
-	xbps_object_t obj;
-	const char *curobj = NULL;
-	/* These are symlinks in Void and must not be removed */
-	const char *basesymlinks[] = {
-		"/bin",
-		"/sbin",
-		"/usr/sbin",
-		"/lib",
-		"/lib32",
-		"/lib64",
-		"/usr/lib32",
-		"/usr/lib64",
-		"/var/run",
-	};
 	int rv = 0;
 
-	assert(xbps_object_type(dict) == XBPS_TYPE_DICTIONARY);
-	assert(key != NULL);
-
-	array = xbps_dictionary_get(dict, key);
-	if (xbps_array_count(array) == 0)
-		return 0;
-
-	iter = xbps_array_iter_from_dict(dict, key);
-	if (iter == NULL)
-		return ENOMEM;
-
-	if (strcmp(key, "files") == 0)
-		curobj = "file";
-	else if (strcmp(key, "conf_files") == 0)
-		curobj = "configuration file";
-	else if (strcmp(key, "links") == 0)
-		curobj = "link";
-	else if (strcmp(key, "dirs") == 0)
-		curobj = "directory";
-
-	xbps_object_iterator_reset(iter);
-
-	/*
-	 * directories must be ordered before removal
-	 */
-	if (strcmp(key, "dirs") == 0) {
-		unsigned int i = 0;
-		unsigned int n = xbps_array_count(array);
-		struct order_length_t *lengths =
-		  (struct order_length_t*) malloc(sizeof(struct order_length_t) * n);
-
-		if (lengths == NULL)
-			return ENOMEM;
-
-		while ((obj = xbps_object_iterator_next(iter))) {
-			const char *file;
-			xbps_dictionary_get_cstring_nocopy(obj, "file", &file);
-			lengths[i].len = strlen(file);
-			lengths[i].pos = i;
-			i++;
-		}
-
-		qsort(lengths, n, sizeof(struct order_length_t), cmp_order_length);
-		dirs = xbps_array_create_with_capacity(n);
-
-		for (i = 0; i < n; i++) {
-			xbps_array_add(dirs, xbps_array_get(array, lengths[i].pos));
-		}
-
-		xbps_object_iterator_release(iter);
-		iter = xbps_array_iterator(dirs);
-		free(lengths);
-	}
-
-	xbps_object_iterator_reset(iter);
-
-	while ((obj = xbps_object_iterator_next(iter))) {
-		const char *file, *sha256;
-		char path[PATH_MAX];
-		bool found;
-
-		xbps_dictionary_get_cstring_nocopy(obj, "file", &file);
-		if (strcmp(xhp->rootdir, "/") == 0)
-			snprintf(path, sizeof(path), "%s", file);
-		else
-			snprintf(path, sizeof(path), "%s%s", xhp->rootdir, file);
-
-		if ((strcmp(key, "files") == 0) ||
-		    (strcmp(key, "conf_files") == 0)) {
-			/*
-			 * Check SHA256 hash in regular files and
-			 * configuration files.
-			 */
-			xbps_dictionary_get_cstring_nocopy(obj,
-			    "sha256", &sha256);
-			rv = xbps_file_hash_check(path, sha256);
-			if (rv == ENOENT) {
-				/* missing file, ignore it */
-				xbps_set_cb_state(xhp,
-				    XBPS_STATE_REMOVE_FILE_HASH_FAIL,
-				    rv, pkgver,
-				    "%s: failed to check hash for %s `%s': %s",
-				    pkgver, curobj, file, strerror(rv));
-				rv = 0;
-				continue;
-			} else if (rv == ERANGE) {
-				rv = 0;
-				if ((xhp->flags &
-				    XBPS_FLAG_FORCE_REMOVE_FILES) == 0) {
-					xbps_set_cb_state(xhp,
-					    XBPS_STATE_REMOVE_FILE_HASH_FAIL,
-					    0, pkgver,
-					    "%s: %s `%s' SHA256 mismatch, "
-					    "preserving file", pkgver,
-					    curobj, file);
-					continue;
-				} else {
-					xbps_set_cb_state(xhp,
-					    XBPS_STATE_REMOVE_FILE_HASH_FAIL,
-					    0, pkgver,
-					    "%s: %s `%s' SHA256 mismatch, "
-					    "forcing removal", pkgver,
-					    curobj, file);
-				}
-			} else if (rv != 0 && rv != ERANGE) {
-				xbps_set_cb_state(xhp,
-				    XBPS_STATE_REMOVE_FILE_HASH_FAIL,
-				    rv, pkgver,
-				    "%s: [remove] failed to check hash for "
-				    "%s `%s': %s", pkgver, curobj, file,
-				    strerror(rv));
-				break;
-			}
-		}
-		/*
-		 * Make sure to not remove any symlink of root directory.
-		 */
-		found = false;
-		for (uint8_t i = 0; i < __arraycount(basesymlinks); i++) {
-			if (strcmp(file, basesymlinks[i]) == 0) {
-				found = true;
-				xbps_dbg_printf(xhp, "[remove] %s ignoring "
-				    "%s removal\n", pkgver, file);
-				break;
-			}
-		}
-		if (found) {
-			continue;
-		}
-		if (strcmp(key, "links") == 0) {
-			const char *target = NULL;
-			char *lnk;
-
-			xbps_dictionary_get_cstring_nocopy(obj, "target", &target);
-			assert(target);
-			lnk = xbps_symlink_target(xhp, path, target);
-			if (lnk == NULL) {
-				xbps_dbg_printf(xhp, "[remove] %s "
-				    "symlink_target: %s\n", path, strerror(errno));
-				continue;
-			}
-			if (strcmp(lnk, target)) {
-				xbps_dbg_printf(xhp, "[remove] %s symlink "
-				    "modified (stored %s current %s)\n", path,
-				    target, lnk);
-				if ((xhp->flags & XBPS_FLAG_FORCE_REMOVE_FILES) == 0) {
-					free(lnk);
-					continue;
-				}
-			}
-			free(lnk);
-		}
+	for (unsigned int i = 0; i < xbps_array_count(obsoletes); i++) {
+		const char *file = NULL;
+		xbps_array_get_cstring_nocopy(obsoletes, i, &file);
 		/*
 		 * Remove the object if possible.
 		 */
-		if (remove(path) == -1) {
+		if (remove(file) == -1) {
 			xbps_set_cb_state(xhp, XBPS_STATE_REMOVE_FILE_FAIL,
 			    errno, pkgver,
-			    "%s: failed to remove %s `%s': %s", pkgver,
-			    curobj, file, strerror(errno));
+			    "%s: failed to remove `%s': %s", pkgver,
+			    file, strerror(errno));
 		} else {
 			/* success */
 			xbps_set_cb_state(xhp, XBPS_STATE_REMOVE_FILE,
-			    0, pkgver, "Removed %s `%s'", curobj, file);
+			    0, pkgver, "Removed `%s'", file);
 		}
 	}
-	xbps_object_iterator_release(iter);
 
 	return rv;
 }
@@ -302,7 +109,8 @@ remove_pkg_files(struct xbps_handle *xhp,
 int HIDDEN
 xbps_remove_pkg(struct xbps_handle *xhp, const char *pkgver, bool update)
 {
-	xbps_dictionary_t pkgd = NULL, pkgfilesd = NULL;
+	xbps_dictionary_t pkgd = NULL, obsd = NULL;
+	xbps_array_t obsoletes;
 	char *pkgname, metafile[PATH_MAX];
 	int rv = 0;
 	pkg_state_t state = 0;
@@ -341,13 +149,6 @@ xbps_remove_pkg(struct xbps_handle *xhp, const char *pkgver, bool update)
 		goto out;
 	}
 
-	/* internalize pkg files dictionary from metadir */
-	snprintf(metafile, sizeof(metafile), "%s/.%s-files.plist", xhp->metadir, pkgname);
-	pkgfilesd = xbps_plist_dictionary_from_file(xhp, metafile);
-	if (pkgfilesd == NULL)
-		xbps_dbg_printf(xhp, "WARNING: metaplist for %s "
-		    "doesn't exist!\n", pkgver);
-
 	/* If package was "half-removed", remove it fully. */
 	if (state == XBPS_PKG_STATE_HALF_REMOVED)
 		goto purge;
@@ -384,29 +185,24 @@ xbps_remove_pkg(struct xbps_handle *xhp, const char *pkgver, bool update)
 		return 0;
 	}
 
-	if (pkgfilesd) {
+	if (xbps_dictionary_get_dict(xhp->transd, "obsolete_files", &obsd))
+		obsoletes = xbps_dictionary_get(obsd, pkgname);
+
+	if (xbps_array_count(obsoletes) > 0) {
 		/*
 		 * Do the removal in 2 phases:
 		 * 	1- check if user has enough perms to remove all entries
 		 * 	2- perform removal
 		 */
-		if (check_remove_pkg_files(xhp, pkgfilesd, pkgver, euid)) {
+		if (check_remove_pkg_files(xhp, obsoletes, pkgver, euid)) {
 			rv = EPERM;
 			goto out;
 		}
 		/* Remove links */
-		if ((rv = remove_pkg_files(xhp, pkgfilesd, "links", pkgver)) != 0)
-			goto out;
-		/* Remove regular files */
-		if ((rv = remove_pkg_files(xhp, pkgfilesd, "files", pkgver)) != 0)
-			goto out;
-		/* Remove configuration files */
-		if ((rv = remove_pkg_files(xhp, pkgfilesd, "conf_files", pkgver)) != 0)
-			goto out;
-		/* Remove dirs */
-		if ((rv = remove_pkg_files(xhp, pkgfilesd, "dirs", pkgver)) != 0)
+		if ((rv = remove_pkg_files(xhp, obsoletes, pkgver)) != 0)
 			goto out;
 	}
+
 	/*
 	 * Execute the post REMOVE action if file exists and we aren't
 	 * updating the package.
@@ -447,6 +243,7 @@ purge:
 	/*
 	 * Remove package metadata plist.
 	 */
+	snprintf(metafile, sizeof(metafile), "%s/.%s-files.plist", xhp->metadir, pkgname);
 	if (remove(metafile) == -1) {
 		if (errno != ENOENT) {
 			xbps_set_cb_state(xhp, XBPS_STATE_REMOVE_FAIL,

--- a/lib/transaction_files.c
+++ b/lib/transaction_files.c
@@ -608,7 +608,7 @@ collect_files(struct xbps_handle *xhp, xbps_dictionary_t d,
 				size = 0;
 #endif
 			rv = collect_file(xhp, file, size, pkgname, pkgver, idx, sha256,
-			    TYPE_FILE, update, removepkg, preserve, removefile, NULL);
+			    TYPE_CONFFILE, update, removepkg, preserve, removefile, NULL);
 			if (rv == EEXIST) {
 				error = true;
 				continue;

--- a/lib/transaction_ops.c
+++ b/lib/transaction_ops.c
@@ -342,6 +342,7 @@ xbps_transaction_update_packages(struct xbps_handle *xhp)
 int
 xbps_transaction_update_pkg(struct xbps_handle *xhp, const char *pkg)
 {
+	xbps_array_t rdeps;
 	int rv;
 
 	rv = xbps_autoupdate(xhp);
@@ -358,6 +359,20 @@ xbps_transaction_update_pkg(struct xbps_handle *xhp, const char *pkg)
 		break;
 	}
 
+	rdeps = xbps_pkgdb_get_pkg_revdeps(xhp, pkg);
+	for (unsigned int i = 0; i < xbps_array_count(rdeps); i++)  {
+		const char *curpkgver = NULL;
+		char *curpkgn;
+
+		xbps_array_get_cstring_nocopy(rdeps, i, &curpkgver);
+		curpkgn = xbps_pkg_name(curpkgver);
+		assert(curpkgn);
+		rv = trans_find_pkg(xhp, curpkgn, false, false);
+		free(curpkgn);
+		xbps_dbg_printf(xhp, "%s: trans_find_pkg %s: %d\n", __func__, curpkgver, rv);
+		if (rv && rv != ENOENT && rv != EEXIST && rv != ENODEV)
+			return rv;
+	}
 	rv = trans_find_pkg(xhp, pkg, false, false);
 	xbps_dbg_printf(xhp, "%s: trans_find_pkg %s: %d\n", __func__, pkg, rv);
 	return rv;
@@ -367,6 +382,7 @@ int
 xbps_transaction_install_pkg(struct xbps_handle *xhp, const char *pkg,
 			     bool reinstall)
 {
+	xbps_array_t rdeps;
 	int rv;
 
 	rv = xbps_autoupdate(xhp);
@@ -382,6 +398,20 @@ xbps_transaction_install_pkg(struct xbps_handle *xhp, const char *pkg,
 		break;
 	}
 
+	rdeps = xbps_pkgdb_get_pkg_revdeps(xhp, pkg);
+	for (unsigned int i = 0; i < xbps_array_count(rdeps); i++)  {
+		const char *curpkgver = NULL;
+		char *curpkgn;
+
+		xbps_array_get_cstring_nocopy(rdeps, i, &curpkgver);
+		curpkgn = xbps_pkg_name(curpkgver);
+		assert(curpkgn);
+		rv = trans_find_pkg(xhp, curpkgn, false, false);
+		free(curpkgn);
+		xbps_dbg_printf(xhp, "%s: trans_find_pkg %s: %d\n", __func__, curpkgver, rv);
+		if (rv && rv != ENOENT && rv != EEXIST && rv != ENODEV)
+			return rv;
+	}
 	rv = trans_find_pkg(xhp, pkg, reinstall, false);
 	xbps_dbg_printf(xhp, "%s: trans_find_pkg %s: %d\n", __func__, pkg, rv);
 	return rv;

--- a/lib/transaction_prepare.c
+++ b/lib/transaction_prepare.c
@@ -272,13 +272,11 @@ xbps_transaction_init(struct xbps_handle *xhp)
 	return 0;
 }
 
-#define MAX_REPEAT 512
-
 int
 xbps_transaction_prepare(struct xbps_handle *xhp)
 {
 	xbps_array_t array, pkgs, edges;
-	unsigned int i, j, cnt;
+	unsigned int i, cnt;
 	int rv = 0;
 
 	if ((rv = xbps_transaction_init(xhp)) != 0)
@@ -287,79 +285,60 @@ xbps_transaction_prepare(struct xbps_handle *xhp)
 	if (xhp->transd == NULL)
 		return ENXIO;
 
-	for (j = 0; j < MAX_REPEAT; j++) {
-		/*
-		 * Collect dependencies for pkgs in transaction.
-		 */
-		if ((edges = xbps_array_create()) == NULL)
-			return ENOMEM;
-		/*
-		 * The edges are also appended after its dependencies have been
-		 * collected; the edges at the original array are removed later.
-		 */
-		pkgs = xbps_dictionary_get(xhp->transd, "packages");
-		assert(xbps_object_type(pkgs) == XBPS_TYPE_ARRAY);
-		cnt = xbps_array_count(pkgs);
-		for (i = 0; i < cnt; i++) {
-			xbps_dictionary_t pkgd;
-			xbps_string_t str;
-			const char *tract = NULL;
-
-			pkgd = xbps_array_get(pkgs, i);
-			str = xbps_dictionary_get(pkgd, "pkgver");
-			xbps_dictionary_get_cstring_nocopy(pkgd, "transaction", &tract);
-			if ((strcmp(tract, "remove") == 0) || strcmp(tract, "hold") == 0)
-				continue;
-
-			assert(xbps_object_type(str) == XBPS_TYPE_STRING);
-
-			if (!xbps_array_add(edges, str))
-				return ENOMEM;
-
-			if ((rv = xbps_repository_find_deps(xhp, pkgs, pkgd)) != 0)
-				return rv;
-
-			if (!xbps_array_add(pkgs, pkgd))
-				return ENOMEM;
-		}
-		/* ... remove dup edges at head */
-		for (i = 0; i < xbps_array_count(edges); i++) {
-			const char *pkgver = NULL;
-			xbps_array_get_cstring_nocopy(edges, i, &pkgver);
-			xbps_remove_pkg_from_array_by_pkgver(pkgs, pkgver);
-		}
-		xbps_object_release(edges);
-
-		/*
-		 * Check for packages to be replaced.
-		 */
-		if ((rv = xbps_transaction_package_replace(xhp, pkgs)) != 0) {
-			xbps_object_release(xhp->transd);
-			xhp->transd = NULL;
-			return rv;
-		}
-		/*
-		 * Check reverse dependencies.
-		 */
-		if ((rv = xbps_transaction_revdeps(xhp, pkgs)) == 0)
-			break;
-		if (rv != EAGAIN)
-			return rv;
-	}
 	/*
-	 * Repeated too many times.
+	 * Collect dependencies for pkgs in transaction.
 	 */
-	if (j == MAX_REPEAT) {
-		xbps_dbg_printf(xhp, "[trans] aborted due to too many repetitions"
-		    " while resolving dependencies!\n");
-		return ELOOP;
-	} else {
-		xbps_dbg_printf(xhp, "[trans] resolved dependencies in"
-		    " %d repetitions.\n", j);
+	if ((edges = xbps_array_create()) == NULL)
+		return ENOMEM;
+	/*
+	 * The edges are also appended after its dependencies have been
+	 * collected; the edges at the original array are removed later.
+	 */
+	pkgs = xbps_dictionary_get(xhp->transd, "packages");
+	assert(xbps_object_type(pkgs) == XBPS_TYPE_ARRAY);
+	cnt = xbps_array_count(pkgs);
+	for (i = 0; i < cnt; i++) {
+		xbps_dictionary_t pkgd;
+		xbps_string_t str;
+		const char *tract = NULL;
+
+		pkgd = xbps_array_get(pkgs, i);
+		str = xbps_dictionary_get(pkgd, "pkgver");
+		xbps_dictionary_get_cstring_nocopy(pkgd, "transaction", &tract);
+		if ((strcmp(tract, "remove") == 0) || strcmp(tract, "hold") == 0)
+			continue;
+
+		assert(xbps_object_type(str) == XBPS_TYPE_STRING);
+
+		if (!xbps_array_add(edges, str))
+			return ENOMEM;
+
+		if ((rv = xbps_repository_find_deps(xhp, pkgs, pkgd)) != 0)
+			return rv;
+
+		if (!xbps_array_add(pkgs, pkgd))
+			return ENOMEM;
+	}
+	/* ... remove dup edges at head */
+	for (i = 0; i < xbps_array_count(edges); i++) {
+		const char *pkgver = NULL;
+		xbps_array_get_cstring_nocopy(edges, i, &pkgver);
+		xbps_remove_pkg_from_array_by_pkgver(pkgs, pkgver);
+	}
+	xbps_object_release(edges);
+
+	/*
+	 * Check for packages to be replaced.
+	 */
+	if ((rv = xbps_transaction_package_replace(xhp, pkgs)) != 0) {
+		xbps_object_release(xhp->transd);
+		xhp->transd = NULL;
+		return rv;
 	}
 	/*
 	 * If there are missing deps or revdeps bail out.
 	 */
+	xbps_transaction_revdeps(xhp, pkgs);
 	array = xbps_dictionary_get(xhp->transd, "missing_deps");
 	if (xbps_array_count(array)) {
 		if (xhp->flags & XBPS_FLAG_FORCE_REMOVE_REVDEPS) {

--- a/lib/transaction_revdeps.c
+++ b/lib/transaction_revdeps.c
@@ -101,21 +101,10 @@ broken_pkg(xbps_array_t mdeps, const char *dep, const char *pkg, const char *tra
 	free(str);
 }
 
-static int
-update_pkg(struct xbps_handle *xhp, const char *pkg)
-{
-	int rv = 0;
-	rv = xbps_transaction_update_pkg(xhp, pkg);
-	if (rv == EEXIST)
-		return 0;
-	return rv;
-}
-
-int HIDDEN
+void HIDDEN
 xbps_transaction_revdeps(struct xbps_handle *xhp, xbps_array_t pkgs)
 {
 	xbps_array_t mdeps;
-	int updated = 0;
 
 	mdeps = xbps_dictionary_get(xhp->transd, "missing_deps");
 
@@ -246,17 +235,9 @@ xbps_transaction_revdeps(struct xbps_handle *xhp, xbps_array_t pkgs)
 				free(pkgname);
 				continue;
 			}
-			if (update_pkg(xhp, pkgname) == 0) {
-				updated++;
-				free(pkgname);
-				continue;
-			}
 			free(pkgname);
 			broken_pkg(mdeps, curpkgver, pkgver, tract);
 		}
 
 	}
-	if (updated > 0)
-		return EAGAIN;
-	return 0;
 }

--- a/tests/xbps/libxbps/shell/install_test.sh
+++ b/tests/xbps/libxbps/shell/install_test.sh
@@ -305,14 +305,12 @@ install_and_update_revdeps_body() {
 	atf_check_equal $? 0
 	xbps-create -A noarch -n C-1.0_1 -s "C pkg" --dependencies "B-1.0_1" ../pkg
 	atf_check_equal $? 0
-	xbps-create -A noarch -n D-1.0_1 -s "D pkg" --dependencies "C>=1.0_1" ../pkg
-	atf_check_equal $? 0
 
 	xbps-rindex -d -a $PWD/*.xbps
 	atf_check_equal $? 0
 
 	cd ..
-	xbps-install -r root --repository=repo -yvd C D
+	xbps-install -r root --repository=repo -yvd C
 	atf_check_equal $? 0
 	atf_check_equal $(xbps-query -r root -p pkgver A) A-1.0_1
 	atf_check_equal $(xbps-query -r root -p pkgver B) B-1.0_1
@@ -323,20 +321,19 @@ install_and_update_revdeps_body() {
 	atf_check_equal $? 0
 	xbps-create -A noarch -n B-1.0_2 -s "B pkg" --dependencies "A-1.0_2" ../pkg
 	atf_check_equal $? 0
-	xbps-create -A noarch -n C-1.0_2 -s "C pkg" --dependencies "A-1.0_2" ../pkg
+	xbps-create -A noarch -n C-1.0_2 -s "C pkg" --dependencies "B-1.0_2" ../pkg
 	atf_check_equal $? 0
-	xbps-create -A noarch -n E-1.0_1 -s "E pkg" --dependencies "C-1.0_2" ../pkg
+	xbps-create -A noarch -n D-1.0_1 -s "D pkg" --dependencies "C-1.0_2" ../pkg
 	atf_check_equal $? 0
 	xbps-rindex -d -a $PWD/*.xbps
 	atf_check_equal $? 0
 	cd ..
-	xbps-install -r root --repository=repo -yvd E
+	xbps-install -r root --repository=repo -yvd D
 	atf_check_equal $? 0
 	atf_check_equal $(xbps-query -r root -p pkgver A) A-1.0_2
 	atf_check_equal $(xbps-query -r root -p pkgver B) B-1.0_2
 	atf_check_equal $(xbps-query -r root -p pkgver C) C-1.0_2
 	atf_check_equal $(xbps-query -r root -p pkgver D) D-1.0_1
-	atf_check_equal $(xbps-query -r root -p pkgver E) E-1.0_1
 }
 
 atf_test_case update_file_timestamps

--- a/tests/xbps/libxbps/shell/remove_test.sh
+++ b/tests/xbps/libxbps/shell/remove_test.sh
@@ -489,6 +489,69 @@ remove_directory_body() {
 	atf_check_equal $? 1
 }
 
+atf_test_case keep_modified_files
+
+keep_modified_files_head() {
+	atf_set "descr" "Tests for package removal: keep modified files in rootdir"
+}
+
+keep_modified_files_body() {
+	mkdir some_repo
+	mkdir -p pkg_A/bin
+	echo "1234" >pkg_A/bin/ash
+	echo "1234" >pkg_A/bin/sh
+
+	cd some_repo
+	xbps-create -A noarch -n A-1.0_1 -s "A pkg" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+	xbps-install -r root -C null.conf --repository=$PWD/some_repo -y A
+	atf_check_equal $? 0
+	echo "keep" >root/bin/sh
+	echo "keep" >root/bin/ash
+
+	xbps-remove -r root -yvd A
+	atf_check_equal $? 0
+	rv=1
+	if [ -e root/bin/sh -a -e root/bin/ash ]; then
+	        rv=0
+	fi
+	atf_check_equal $rv 0
+}
+
+atf_test_case remove_modified_files
+
+remove_modified_files_head() {
+	atf_set "descr" "Tests for package removal: force remove modified files in rootdir"
+}
+
+remove_modified_files_body() {
+	mkdir some_repo
+	mkdir -p pkg_A/bin
+	echo "1234" >pkg_A/bin/ash
+	echo "1234" >pkg_A/bin/sh
+
+	cd some_repo
+	xbps-create -A noarch -n A-1.0_1 -s "A pkg" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+	xbps-install -r root -C null.conf --repository=$PWD/some_repo -y A
+	atf_check_equal $? 0
+	echo "don't keep" >root/bin/sh
+	echo "don't keep" > root/bin/ash
+
+	xbps-remove -r root -yvdf A
+	atf_check_equal $? 0
+	rv=0
+	[ -e root/bin/sh ] && rv=1
+	[ -e root/bin/ash ] && rv=1
+	atf_check_equal $rv 0
+}
+
 atf_init_test_cases() {
 	atf_add_test_case keep_base_symlinks
 	atf_add_test_case keep_modified_symlinks
@@ -507,4 +570,6 @@ atf_init_test_cases() {
 	atf_add_test_case remove_with_revdeps_in_trans_inverted
 	atf_add_test_case remove_with_revdeps_in_trans_recursive
 	atf_add_test_case remove_directory
+	atf_add_test_case keep_modified_files
+	atf_add_test_case remove_modified_files
 }


### PR DESCRIPTION
This reverts some changes, I'm not really sure about because they influence the installation order of found reverse dependencies and might be slow in certain cases.

The biggest change is that the transaction file checks are used for package removal, this fixes removing wrong files and removes a lot of duplicated code.

Another big reason to get this release out, is fixing obsoletes removal.

I plan to add the other 3 issues from the milestone to this PR:
https://github.com/void-linux/xbps/milestone/2

Some other patches are minor and/or were already added to the live version.