### PR TITLE
Archive write errors

### DIFF
--- a/lib/archive.c
+++ b/lib/archive.c
@@ -83,7 +83,8 @@ xbps_archive_append_buf(struct archive *ar, const void *buf, const size_t buflen
 	assert(gname);
 
 	entry = archive_entry_new();
-	assert(entry);
+	if (entry == NULL)
+		return archive_errno(ar);
 
 	archive_entry_set_filetype(entry, AE_IFREG);
 	archive_entry_set_perm(entry, mode);
@@ -100,7 +101,10 @@ xbps_archive_append_buf(struct archive *ar, const void *buf, const size_t buflen
 		archive_entry_free(entry);
 		return archive_errno(ar);
 	}
-	archive_write_finish_entry(ar);
+	if (archive_write_finish_entry(ar) != ARCHIVE_OK) {
+		archive_entry_free(entry);
+		return archive_errno(ar);
+	}
 	archive_entry_free(entry);
 
 	return 0;


### PR DESCRIPTION
This resolves the issues we've seen when `/hostdir` is full.

1. `xbps-rindex` would overwrite repodata with an empty file if some of the writes fail, in our case we lost some staged packages from the index. 
1. `xbps-create` would create incomplete archives that can't be added to the repository index and would also make `xbps-src` skip registering a new build until all corrupt `.xbps` files were removed manually.