### PR TITLE
xbps-{uunshare,uchroot}: restrict option parsing

### DIFF
--- a/bin/xbps-uchroot/main.c
+++ b/bin/xbps-uchroot/main.c
@@ -281,7 +281,7 @@ main(int argc, char **argv)
 	tmpfs_opts = chrootdir = cmd = NULL;
 	argv0 = argv[0];
 
-	while ((c = getopt_long(argc, argv, "Oto:b:V", longopts, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "+Oto:b:V", longopts, NULL)) != -1) {
 		switch (c) {
 		case 'O':
 			overlayfs = true;

--- a/bin/xbps-uunshare/main.c
+++ b/bin/xbps-uunshare/main.c
@@ -136,7 +136,7 @@ main(int argc, char **argv)
 	chrootdir = cmd = NULL;
 	argv0 = argv[0];
 
-	while ((c = getopt_long(argc, argv, "b:V", longopts, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "+b:V", longopts, NULL)) != -1) {
 		switch (c) {
 		case 'b':
 			if (optarg == NULL || *optarg == '\0')


### PR DESCRIPTION
GNU's getopt(3) and getopt_long(3) allows options anywhere in the
command. Thus, crippling (-b /tmp:/tmp is used for cosmetic, but not
required to demonstrate the problem):

    xbps-uunshare -b /tmp:/tmp /masterdir sh -c 'echo yes'

We could use:

    xbps-uunshare -b /tmp:/tmp -- /masterdir sh -c 'echo yes'

to overcome that problem but it isn't documented in our man-pages.

Consider the limited usage of this utility, just stop parsing options
when we get our first non-options argument.

Signed-off-by: Doan Tran Cong Danh <congdanhqx@gmail.com>
