### PR TITLE
xbps-checkvers: use binpkg's pkgname rather than srcpkgs.

### DIFF
--- a/bin/xbps-checkvers/main.c
+++ b/bin/xbps-checkvers/main.c
@@ -366,6 +366,21 @@ rcv_get_pkgver(rcv_t *rcv)
 		else
 			val = strndup(v, vlen);
 
+		/*
+		 * Do not override binary package "pkgname"
+		 * with the one from template, because the
+		 * former might be a subpkg.
+		 */
+		if (strcmp(key, "pkgname") == 0) {
+			char *s;
+			size_t len;
+
+			free(val);
+			s = strchr(rcv->fname, '/');
+			len = s ? strlen(rcv->fname) - strlen(s) : strlen(rcv->fname);
+			val = strndup(rcv->fname, len);
+			assert(val);
+		}
 		if (!xbps_dictionary_set(rcv->env, key,
 		    xbps_string_create_cstring(val))) {
 			fprintf(stderr, "error: xbps_dictionary_set");

--- a/tests/xbps/xbps-checkvers/checkvers_test.sh
+++ b/tests/xbps/xbps-checkvers/checkvers_test.sh
@@ -462,6 +462,41 @@ EOF
 	atf_check_equal "$out" "process ? 1_1 process ?"
 }
 
+atf_test_case subpkg
+
+subpkg_head() {
+	atf_set "descr" "xbps-checkvers(1): test subpkgs"
+}
+subpkg_body() {
+	mkdir -p some_repo pkg_A void-packages/srcpkgs/A
+	touch pkg_A/file00
+	cat > void-packages/srcpkgs/A/template <<EOF
+pkgname=A
+version=1.0
+revision=1
+}
+EOF
+	ln -s A void-packages/srcpkgs/A-subpkg
+	ln -s A void-packages/srcpkgs/B-subpkg
+	cd some_repo
+	xbps-create -A noarch -n A-subpkg-1.1_1 -s "A-subpkg pkg" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+	out=$(xbps-checkvers -i -R $PWD/some_repo -D $PWD/void-packages -sm A-subpkg)
+	atf_check_equal $? 0
+	atf_check_equal "$out" "A-subpkg 1.1_1 1.0_1 A-subpkg $PWD/some_repo"
+
+	out=$(xbps-checkvers -i -R $PWD/some_repo -D $PWD/void-packages -sm B-subpkg)
+	atf_check_equal $? 0
+	atf_check_equal "$out" "B-subpkg ? 1.0_1 B-subpkg ?"
+
+	out=$(xbps-checkvers -i -R $PWD/some_repo -D $PWD/void-packages -sm A)
+	atf_check_equal $? 0
+	atf_check_equal "$out" "A ? 1.0_1 A ?"
+}
+
 atf_init_test_cases() {
 	atf_add_test_case srcpkg_newer
 	atf_add_test_case srcpkg_newer_with_refs
@@ -479,4 +514,5 @@ atf_init_test_cases() {
 	atf_add_test_case reverts_alpha
 	atf_add_test_case reverts_many
 	atf_add_test_case manual_mode
+	atf_add_test_case subpkg
 }


### PR DESCRIPTION
Up until now `xbps-checkvers` would only check for the
real sourcepkg, this broke detection of binary packages
that are subpkgs.

Added a new test case.

Close #192