### PR TITLE
Do not silently update xbps on any install/update transaction.

### DIFF
--- a/include/xbps.h.in
+++ b/include/xbps.h.in
@@ -50,7 +50,7 @@
  *
  * This header documents the full API for the XBPS Library.
  */
-#define XBPS_API_VERSION	"20190707"
+#define XBPS_API_VERSION	"20191227"
 
 #ifndef XBPS_VERSION
  #define XBPS_VERSION		"UNSET"

--- a/lib/transaction_ops.c
+++ b/lib/transaction_ops.c
@@ -297,8 +297,8 @@ xbps_transaction_update_packages(struct xbps_handle *xhp)
 	rv = xbps_autoupdate(xhp);
 	switch (rv) {
 	case 1:
-		/* xbps needs to be updated, don't add any other package */
-		return 0;
+		/* xbps needs to be updated, don't allow any other update */
+		return EBUSY;
 	case -1:
 		/* error */
 		return EINVAL;
@@ -349,7 +349,9 @@ xbps_transaction_update_pkg(struct xbps_handle *xhp, const char *pkg)
 	xbps_dbg_printf(xhp, "%s: xbps_autoupdate %d\n", __func__, rv);
 	switch (rv) {
 	case 1:
-		/* xbps needs to be updated, don't add any other package */
+		/* xbps needs to be updated, only allow xbps to be updated */
+		if (strcmp(pkg, "xbps"))
+			return EBUSY;
 		return 0;
 	case -1:
 		/* error */
@@ -388,7 +390,9 @@ xbps_transaction_install_pkg(struct xbps_handle *xhp, const char *pkg,
 	rv = xbps_autoupdate(xhp);
 	switch (rv) {
 	case 1:
-		/* xbps needs to be updated, don't add any other package */
+		/* xbps needs to be updated, only allow xbps to be updated */
+		if (strcmp(pkg, "xbps"))
+			return EBUSY;
 		return 0;
 	case -1:
 		/* error */

--- a/tests/xbps/libxbps/shell/install_test.sh
+++ b/tests/xbps/libxbps/shell/install_test.sh
@@ -488,6 +488,20 @@ update_xbps_body() {
 	set -- $out
 	exp="$1 $2 $3 $4"
 	atf_check_equal "$exp" "xbps-1.1_1 update noarch $(readlink -f repo)"
+
+	xbps-install -r root --repository=repo -yu xbps
+	atf_check_equal $? 0
+
+	out=$(xbps-query -r root -p pkgver xbps)
+	atf_check_equal "$out" "xbps-1.1_1"
+
+	xbps-install -r root --repository=repo -yu
+	atf_check_equal $? 0
+
+	out=$(xbps-query -r root -p pkgver B)
+	atf_check_equal "$out" "B-1.1_1"
+	out=$(xbps-query -r root -p pkgver C)
+	atf_check_equal "$out" "C-1.1_1"
 }
 
 atf_test_case update_xbps_virtual
@@ -527,6 +541,12 @@ update_xbps_virtual_body() {
 	set -- $out
 	exp="$1 $2 $3 $4"
 	atf_check_equal "$exp" "xbps-git-1.1_1 update noarch $(readlink -f repo)"
+
+	xbps-install -r root --repository=repo -yu xbps
+	atf_check_equal $? 0
+
+	out=$(xbps-query -r root -p pkgver xbps-git)
+	atf_check_equal "$out" "xbps-git-1.1_1"
 }
 
 atf_test_case update_with_revdeps

--- a/tests/xbps/libxbps/shell/update_itself_test.sh
+++ b/tests/xbps/libxbps/shell/update_itself_test.sh
@@ -30,7 +30,14 @@ update_xbps_body() {
 	atf_check_equal $? 0
 	cd ..
 
+	# EBUSY
 	xbps-install -r root --repository=$PWD/repo -yud
+	atf_check_equal $? 16
+
+	out=$(xbps-query -r root -p pkgver xbps)
+	atf_check_equal $out xbps-1.0_1
+
+	xbps-install -r root --repository=$PWD/repo -yu xbps
 	atf_check_equal $? 0
 
 	out=$(xbps-query -r root -p pkgver xbps)
@@ -40,7 +47,7 @@ update_xbps_body() {
 atf_test_case update_xbps_with_revdeps
 
 update_xbps_with_revdeps_head() {
-	atf_set "descr" "Tests for pkg updates: xbps autoupdates itself with revdeps"
+	atf_set "descr" "Tests for pkg updates: xbps updates itself with revdeps"
 }
 
 update_xbps_with_revdeps_body() {
@@ -80,8 +87,11 @@ update_xbps_with_revdeps_body() {
 	atf_check_equal $? 0
 	cd ..
 
-	# first time, xbps autoupdates
+	# first time, xbps must be updated (returns EBUSY)
 	xbps-install -r root --repository=$PWD/repo -yud
+	atf_check_equal $? 16
+
+	xbps-install -r root --repository=$PWD/repo -yu xbps
 	atf_check_equal $? 0
 
 	out=$(xbps-query -r root -p pkgver xbps)
@@ -110,7 +120,7 @@ update_xbps_with_revdeps_body() {
 atf_test_case update_xbps_with_uptodate_revdeps
 
 update_xbps_with_uptodate_revdeps_head() {
-	atf_set "descr" "Tests for pkg updates: xbps autoupdates itself with already up-to-date revdeps"
+	atf_set "descr" "Tests for pkg updates: xbps updates itself with already up-to-date revdeps"
 }
 
 update_xbps_with_uptodate_revdeps_body() {
@@ -143,6 +153,9 @@ update_xbps_with_uptodate_revdeps_body() {
 	cd ..
 
 	xbps-install -r root --repository=$PWD/repo -yud
+	atf_check_equal $? 16
+
+	xbps-install -r root --repository=$PWD/repo -yu xbps
 	atf_check_equal $? 0
 
 	out=$(xbps-query -r root -p pkgver xbps)
@@ -154,78 +167,8 @@ update_xbps_with_uptodate_revdeps_body() {
 
 atf_test_case update_xbps_on_any_op
 
-update_xbps_on_any_op_head() {
-	atf_set "descr" "Tests for pkg updates: xbps autoupdates itself on any operation"
-}
-
-update_xbps_on_any_op_body() {
-	mkdir -p repo xbps foo bar
-	touch xbps/foo foo/blah bar/baz
-
-	cd repo
-	xbps-create -A noarch -n xbps-1.0_1 -s "xbps pkg" ../xbps
-	atf_check_equal $? 0
-	xbps-create -A noarch -n foo-1.0_1 -s "foo pkg" ../foo
-	atf_check_equal $? 0
-	xbps-create -A noarch -n bar-1.0_1 -s "bar pkg" ../bar
-	atf_check_equal $? 0
-	xbps-rindex -d -a $PWD/*.xbps
-	atf_check_equal $? 0
-	cd ..
-
-	xbps-install -r root --repository=$PWD/repo -yd xbps foo
-	atf_check_equal $? 0
-
-	out=$(xbps-query -r root -p pkgver xbps)
-	atf_check_equal $out xbps-1.0_1
-
-	out=$(xbps-query -r root -p pkgver foo)
-	atf_check_equal $out foo-1.0_1
-
-	cd repo
-	xbps-create -A noarch -n xbps-1.1_1 -s "xbps pkg" ../xbps
-	atf_check_equal $? 0
-	xbps-create -A noarch -n foo-1.1_1 -s "foo pkg" ../foo
-	atf_check_equal $? 0
-	xbps-rindex -d -a $PWD/*.xbps
-	atf_check_equal $? 0
-	cd ..
-
-	# install an unrelated pkg, xbps autoupdates
-	xbps-install -r root --repository=$PWD/repo -yd bar
-	atf_check_equal $? 0
-
-	out=$(xbps-query -r root -p pkgver xbps)
-	atf_check_equal $out xbps-1.1_1
-
-	out=$(xbps-query -r root -p pkgver foo)
-	atf_check_equal $out foo-1.0_1
-
-	# ENOENT
-	xbps-query -r root -p pkgver bar
-	atf_check_equal $? 2
-
-	# xbps has been updated, 2nd time
-	xbps-install -r root --repository=$PWD/repo -yd bar
-	atf_check_equal $? 0
-
-	out=$(xbps-query -r root -p pkgver bar)
-	atf_check_equal $out bar-1.0_1
-
-	# perform a globl update
-	xbps-install -r root --repository=$PWD/repo -yud
-	atf_check_equal $? 0
-
-	out=$(xbps-query -r root -p pkgver xbps)
-	atf_check_equal $out xbps-1.1_1
-
-	out=$(xbps-query -r root -p pkgver foo)
-	atf_check_equal $out foo-1.1_1
-}
-
 atf_init_test_cases() {
 	atf_add_test_case update_xbps
 	atf_add_test_case update_xbps_with_revdeps
 	atf_add_test_case update_xbps_with_uptodate_revdeps
-	atf_add_test_case update_xbps_on_any_op
 }


### PR DESCRIPTION
When there's a new xbps update, xbps-install(1) will now return
EBUSY (16) and a message (if dry-run disabled) explaining
how to proceed.

If there's an update and transaction does not contain xbps, it will
error out unless the 'xbps' pkg is the only target pkg, i.e:

```
	# xbps-install -u
        The 'xbps' package must be updated, please run `xbps-install -u xbps`
	# echo $?
	16
```

To update xbps, the only way to proceed is to explicitly declare
it as an update, i.e:

```
	# xbps-install -u xbps
```

The dry-run mode will still show there's an xbps update.

Modified the existing test cases to satisfy the new behaviour.

Closes #166
Closes #142