### PR TITLE
xbps_init: autodetect musl libc variant at compile time.

### DIFF
--- a/lib/initend.c
+++ b/lib/initend.c
@@ -107,10 +107,20 @@ xbps_init(struct xbps_handle *xhp)
 	if ((native_arch = getenv("XBPS_ARCH")) != NULL) {
 		xbps_strlcpy(xhp->native_arch, native_arch, sizeof (xhp->native_arch));
 	} else {
+		char *s = NULL;
 		struct utsname un;
 		if (uname(&un) == -1)
 			return ENOTSUP;
+#if defined(__linux__) && !defined(__GLIBC__)
+		/* musl libc on linux */
+		s = xbps_xasprintf("%s-musl", un.machine);
+		assert(s);
+		xbps_strlcpy(xhp->native_arch, s, sizeof(xhp->native_arch));
+		free(s);
+#else
+		/* glibc or any other os */
 		xbps_strlcpy(xhp->native_arch, un.machine, sizeof (xhp->native_arch));
+#endif
 	}
 	assert(xhp->native_arch);
 

--- a/lib/initend.c
+++ b/lib/initend.c
@@ -107,7 +107,10 @@ xbps_init(struct xbps_handle *xhp)
 	if ((native_arch = getenv("XBPS_ARCH")) != NULL) {
 		xbps_strlcpy(xhp->native_arch, native_arch, sizeof (xhp->native_arch));
 	} else {
+#if defined(__linux__) && !defined(__GLIBC__)
+		/* musl libc on linux */
 		char *s = NULL;
+#endif
 		struct utsname un;
 		if (uname(&un) == -1)
 			return ENOTSUP;

--- a/tests/xbps/libxbps/shell/scripts_test.sh
+++ b/tests/xbps/libxbps/shell/scripts_test.sh
@@ -41,7 +41,7 @@ script_nargs_body() {
 	rval=0
 	xbps-reconfigure -C empty.conf -r root -f A 2>out
 	out="$(cat out)"
-	expected="post A 1.0_1 no no $(uname -m)"
+	expected="post A 1.0_1 no no $(xbps-uhelper arch)"
 	if [ "$out" != "$expected" ]; then
 		echo "out: '$out'"
 		echo "expected: '$expected'"

--- a/tests/xbps/xbps-uhelper/arch_test.sh
+++ b/tests/xbps/xbps-uhelper/arch_test.sh
@@ -8,7 +8,12 @@ native_head() {
 }
 
 native_body() {
-	atf_check_equal $(xbps-uhelper arch) $(uname -m)
+	if $(ldd --version 2>&1|head -1|grep -q musl); then
+		arch=$(uname -m)-musl
+	else
+		arch=$(uname -m)
+	fi
+	atf_check_equal $(xbps-uhelper arch) $arch
 }
 
 atf_test_case env
@@ -28,8 +33,8 @@ conf_head() {
 }
 conf_body() {
 	mkdir -p xbps.d
-	echo "architecture=x86_64-musl" > xbps.d/arch.conf
-	atf_check_equal $(xbps-uhelper -C $PWD/xbps.d arch) x86_64-musl
+	echo "architecture=NULL" > xbps.d/arch.conf
+	atf_check_equal $(xbps-uhelper -C $PWD/xbps.d arch) NULL
 }
 
 atf_init_test_cases() {


### PR DESCRIPTION
This way we don't need to set the 'architecture' xbps.d
setting when the binaries are compiled for musl.

Close #195