### PR TITLE
Revert "libxbps: verify repodata signatures even if rootdir is unset."

### DIFF
--- a/lib/verifysig.c
+++ b/lib/verifysig.c
@@ -97,12 +97,7 @@ xbps_verify_signature(struct xbps_repo *repo, const char *sigfile,
 	/*
 	 * Prepare repository RSA public key to verify fname signature.
 	 */
-	/* XXX: xbps-rindex does not set rootdir, use cwd and fallback to defaults otherwise */
-	rkeyfile = xbps_xasprintf("keys/%s.plist", hexfp);
-	if (access(rkeyfile, R_OK) == -1) {
-		free(rkeyfile);
-		rkeyfile = xbps_xasprintf("%s/keys/%s.plist", repo->xhp->metadir, hexfp);
-	}
+	rkeyfile = xbps_xasprintf("%s/keys/%s.plist", repo->xhp->metadir, hexfp);
 	repokeyd = xbps_plist_dictionary_from_file(repo->xhp, rkeyfile);
 	if (xbps_object_type(repokeyd) != XBPS_TYPE_DICTIONARY) {
 		xbps_dbg_printf(repo->xhp, "cannot read rkey data at %s: %s\n",


### PR DESCRIPTION
Only read keys from dedicated directory.