### PR TITLE
Fix digest

### DIFF
--- a/bin/xbps-fetch/xbps-fetch.1
+++ b/bin/xbps-fetch/xbps-fetch.1
@@ -1,4 +1,4 @@
-.Dd June 12, 2019
+.Dd January 18, 2020
 .Dt XBPS-FETCH 1
 .Sh NAME
 .Nm xbps-fetch
@@ -28,6 +28,8 @@ Rename file from specified URL to
 .Ar output .
 .It Fl v
 Enables verbose messages.
+.It Fl s
+Print sha256sums of downloaded files.
 .It Fl V
 Show the version information.
 .El


### PR DESCRIPTION
First commit fixes the checksum output if a download was continued.

Second commit adds a checksum output to `xbps-fetch(1)`, I mainly did this to easily test the fix but I think this could be useful for xbps-src because large downloads can be fetched and the checksum generated at the same time.