### PR TITLE
change to allow non-root user to use xbps-install --download-only --c…

### DIFF
--- a/bin/xbps-install/main.c
+++ b/bin/xbps-install/main.c
@@ -243,7 +243,9 @@ main(int argc, char **argv)
 	if (syncf && !update && (argc == optind))
 		exit(EXIT_SUCCESS);
 
-	if (!drun && (rv = xbps_pkgdb_lock(&xh)) != 0) {
+	/* allow non-root user to use --download-only -- still lock pkgdb if euid==root just in case ... */
+	/* not dryrun  AND  not (downloadonly && notroot) AND lockpkgDB */
+	if (!drun && !((flags & XBPS_FLAG_DOWNLOAD_ONLY) && geteuid()) && (rv = xbps_pkgdb_lock(&xh)) != 0) {
 		fprintf(stderr, "Failed to lock the pkgdb: %s\n", strerror(rv));
 		exit(rv);
 	}


### PR DESCRIPTION
…ache-dir mycache

I added a check for the the root euid, since if the euid is root, the pkgdb could be written, so in that case we should still lock the pkgdb

Perhaps I need to look further at your code base as some of my edits go past 80 chars per line.