### PR TITLE
RFC: configuration: add keepconf option

### DIFF
--- a/data/xbps.conf
+++ b/data/xbps.conf
@@ -71,6 +71,20 @@
 #	preserve=/etc/file
 #	preserve=/etc/dir/*.conf
 
+## PRESERVING CONFIGURATION
+#
+# The `keepconf` (disabled by default) keyword can be used to prevent
+# xbps from overwriting configuration files.
+#
+# If set to false, xbps will overwrite configuration files if they
+# have not been changed since installation and a newer version is
+# available.
+#
+# If set to true, xbps will save the new configuration file as
+# <name>.new-<version> if the original configuration file has not been
+# changed since installation.
+# keepconf=true
+
 ## VIRTUAL PACKAGES
 #
 # Virtual package overrides. You can set your own list of preferred virtual

--- a/data/xbps.d.5
+++ b/data/xbps.d.5
@@ -1,4 +1,4 @@
-.Dd January 18, 2020
+.Dd February 05, 2020
 .Dt XBPS-D 5
 .Sh NAME
 .Nm xbps.d
@@ -84,6 +84,15 @@ Absolute path to a file and file globbing are supported, example:
 .It Sy preserve=/usr/bin/foo
 .It Sy preserve=/etc/foo/*.conf
 .El
+.It Sy keepconf=true|false
+If set to false (default), xbps will overwrite configuration files if
+they have not been changed since installation and a newer version is
+available.
+.Pp
+If set to true, xbps will save the new configuration file as
+<name>.new-<version> if the original configuration file has not been
+changed since installation.
+.Pp
 .It Sy repository=url
 Declares a package repository. The
 .Ar url

--- a/include/xbps.h.in
+++ b/include/xbps.h.in
@@ -232,6 +232,14 @@
 #define XBPS_FLAG_INSTALL_REPRO		0x00008000
 
 /**
+ * @def XBPS_FLAG_KEEP_CONFIG
+ * Don't overwrite configuration files that have not changed since
+ * installation.
+ * Must be set through the xbps_handle::flags member.
+ */
+#define XBPS_FLAG_KEEP_CONFIG	0x00010000
+
+/**
  * @def XBPS_FETCH_CACHECONN
  * Default (global) limit of cached connections used in libfetch.
  */

--- a/lib/conf.c
+++ b/lib/conf.c
@@ -171,6 +171,7 @@ enum {
 	KEY_ROOTDIR,
 	KEY_SYSLOG,
 	KEY_VIRTUALPKG,
+	KEY_KEEPCONF,
 };
 
 static const struct key {
@@ -189,6 +190,7 @@ static const struct key {
 	{ "rootdir",       7, KEY_ROOTDIR },
 	{ "syslog",        6, KEY_SYSLOG },
 	{ "virtualpkg",   10, KEY_VIRTUALPKG },
+	{ "keepconf",      8, KEY_KEEPCONF },
 };
 
 static int
@@ -355,6 +357,15 @@ parse_file(struct xbps_handle *xhp, const char *path, bool nested)
 			break;
 		case KEY_PRESERVE:
 			store_preserved_file(xhp, val);
+			break;
+		case KEY_KEEPCONF:
+			if (strcasecmp(val, "true") == 0) {
+				xhp->flags |= XBPS_FLAG_KEEP_CONFIG;
+				xbps_dbg_printf(xhp, "%s: config preservation enabled\n", path);
+			} else {
+				xhp->flags &= ~XBPS_FLAG_KEEP_CONFIG;
+				xbps_dbg_printf(xhp, "%s: config preservation disabled\n", path);
+			}
 			break;
 		case KEY_BESTMATCHING:
 			if (strcasecmp(val, "true") == 0) {

--- a/lib/initend.c
+++ b/lib/initend.c
@@ -181,6 +181,7 @@ xbps_init(struct xbps_handle *xhp)
 	xbps_dbg_printf(xhp, "sysconfdir=%s\n", xhp->sysconfdir);
 	xbps_dbg_printf(xhp, "syslog=%s\n", xhp->flags & XBPS_FLAG_DISABLE_SYSLOG ? "false" : "true");
 	xbps_dbg_printf(xhp, "bestmatching=%s\n", xhp->flags & XBPS_FLAG_BESTMATCH ? "true" : "false");
+	xbps_dbg_printf(xhp, "keepconf=%s\n", xhp->flags & XBPS_FLAG_KEEP_CONFIG ? "true" : "false");
 	xbps_dbg_printf(xhp, "Architecture: %s\n", xhp->native_arch);
 	xbps_dbg_printf(xhp, "Target Architecture: %s\n", xhp->target_arch);
 

--- a/lib/package_config_files.c
+++ b/lib/package_config_files.c
@@ -170,11 +170,13 @@ xbps_entry_install_conf_file(struct xbps_handle *xhp,
 		/*
 		 * Orig = X, Curr = X, New = Y
 		 *
-		 * Install new file (installed file hasn't been modified).
+		 * Install new file (installed file hasn't been modified) if
+		 * configuration option keepconfig is NOT set.
 		 */
 		} else if ((strcmp(sha256_orig, sha256_cur) == 0) &&
 			   (strcmp(sha256_orig, sha256_new)) &&
-			   (strcmp(sha256_cur, sha256_new))) {
+			   (strcmp(sha256_cur, sha256_new)) &&
+			   (!(xhp->flags & XBPS_FLAG_KEEP_CONFIG))) {
 			xbps_set_cb_state(xhp, XBPS_STATE_CONFIG_FILE,
 			    0, pkgver,
 			    "Updating configuration file `%s' provided "
@@ -212,12 +214,15 @@ xbps_entry_install_conf_file(struct xbps_handle *xhp,
 			break;
 		/*
 		 * Orig = X, Curr = Y, New = Z
+		 * or
+		 * Orig = X, Curr = X, New = Y if keepconf is set
 		 *
 		 * Install new file as <file>.new-<version>
 		 */
-		} else  if ((strcmp(sha256_orig, sha256_cur)) &&
+		} else if (((strcmp(sha256_orig, sha256_cur)) &&
 			    (strcmp(sha256_cur, sha256_new)) &&
-			    (strcmp(sha256_orig, sha256_new))) {
+			    (strcmp(sha256_orig, sha256_new))) ||
+			    (xhp->flags & XBPS_FLAG_KEEP_CONFIG)) {
 			version = xbps_pkg_version(pkgver);
 			assert(version);
 			snprintf(buf, sizeof(buf), ".%s.new-%s", cffile, version);


### PR DESCRIPTION
Add configuration option keepconf that stops xbps from overwriting
unchanged configuration files. If keepconf=true, xbps will store the new
configuration as <name>.new-<version> instead of overwriting unchanged
configuration files.

On production servers which I take care of, there are a number of different programs using default configuration. When upgrading, xbps normally overwrites an unchanged configuration with new defaults. This can lead to the server behaving unexpectedly. This is an RFC/PoC for adding a configuration knob that allows preventing xbps from overwriting default configuration, giving the user complete control.

Is this a good idea?