### PR TITLE
xbps-fetch: TIMEOUT_CONNECTION to customize time waiting for response

### DIFF
--- a/bin/xbps-fetch/xbps-fetch.1
+++ b/bin/xbps-fetch/xbps-fetch.1
@@ -82,6 +82,10 @@ Overrides the default CA certificates path, by default set to
 Sets the SSL/TLS client verification certificate file.
 .It Sy SSL_CLIENT_KEY_FILE
 Sets the SSL/TLS client verification key file.
+.It Sy CONNECTION_TIMEOUT
+Sets connection timeout in milliseconds
+instead of default value of 5 minutes.
+When -1, waits indefinitely.
 .El
 .Sh SEE ALSO
 .Xr xbps-checkvers 1 ,


### PR DESCRIPTION
Allows to [configure CI job](https://github.com/Chocimier/void-packages-org/commit/a09733b7748ede191a4cbf44bc447952d96bdf63) to build from ftp source without taking too much time as [demostrated with chrootkit](https://travis-ci.org/Chocimier/void-packages-org/builds/647493514).