### PR TITLE
libxbps: avoid malloc in xbps_file_hash{,_raw}.

### DIFF
--- a/bin/xbps-create/main.c
+++ b/bin/xbps-create/main.c
@@ -437,6 +437,7 @@ ftw_cb(const char *fpath, const struct stat *sb, const struct dirent *dir UNUSED
 		xbps_object_t obj;
 		xbps_dictionary_t linkinfo;
 		uint64_t inode = 0;
+		char digest[128];
 		/*
 		 * Regular files. First find out if it's a hardlink:
 		 * 	- st_nlink > 1
@@ -480,11 +481,10 @@ ftw_cb(const char *fpath, const struct stat *sb, const struct dirent *dir UNUSED
 		}
 
 		assert(xe->type);
-		if ((p = xbps_file_hash(fpath)) == NULL)
+		if (!xbps_file_hash(digest, sizeof(digest), fpath))
 			die("failed to process hash for %s:", fpath);
-		xbps_dictionary_set_cstring(fileinfo, "sha256", p);
-		free(p);
-		if ((xe->hash = xbps_file_hash(fpath)) == NULL)
+		xbps_dictionary_set_cstring(fileinfo, "sha256", digest);
+		if ((xe->hash = strdup(digest)) == NULL)
 			die("failed to process hash for %s:", fpath);
 
 		xbps_dictionary_set_uint64(fileinfo, "inode", sb->st_ino);

--- a/bin/xbps-digest/main.c
+++ b/bin/xbps-digest/main.c
@@ -53,7 +53,7 @@ int
 main(int argc, char **argv)
 {
 	int c;
-	char *hash = NULL;
+	char hash[128];
 	const char *mode = NULL, *progname = argv[0];
 	const struct option longopts[] = {
 		{ NULL, 0, NULL, 0 }
@@ -84,23 +84,19 @@ main(int argc, char **argv)
 	}
 
 	if (argc < 1) {
-		hash = xbps_file_hash("/dev/stdin");
-		if (hash == NULL)
+		if (!xbps_file_hash(hash, sizeof(hash), "/dev/stdin"))
 			exit(EXIT_FAILURE);
 
 		printf("%s\n", hash);
-		free(hash);
 	} else {
 		for (int i = 0; i < argc; i++) {
-			hash = xbps_file_hash(argv[i]);
-			if (hash == NULL) {
+			if (!xbps_file_hash(hash, sizeof(hash), argv[i])) {
 				fprintf(stderr,
 				    "%s: couldn't get hash for %s (%s)\n",
 				progname, argv[i], strerror(errno));
 				exit(EXIT_FAILURE);
 			}
 			printf("%s\n", hash);
-			free(hash);
 		}
 	}
 	exit(EXIT_SUCCESS);

--- a/bin/xbps-rindex/index-add.c
+++ b/bin/xbps-rindex/index-add.c
@@ -252,8 +252,9 @@ index_add(struct xbps_handle *xhp, int args, int argmax, char **argv, bool force
 	 */
 	for (int i = args; i < argmax; i++) {
 		const char *arch = NULL, *pkg = argv[i];
-		char *sha256 = NULL, *pkgver = NULL;
+		char *pkgver = NULL;
 		char pkgname[XBPS_NAME_SIZE];
+		char sha256[128];
 
 		assert(pkg);
 		/*
@@ -331,7 +332,7 @@ index_add(struct xbps_handle *xhp, int args, int argmax, char **argv, bool force
 		 * 	- filename-size
 		 * 	- filename-sha256
 		 */
-		if ((sha256 = xbps_file_hash(pkg)) == NULL) {
+		if (!xbps_file_hash(sha256, sizeof(sha256), pkg)) {
 			xbps_object_release(binpkgd);
 			free(pkgver);
 			rv = EINVAL;
@@ -339,12 +340,10 @@ index_add(struct xbps_handle *xhp, int args, int argmax, char **argv, bool force
 		}
 		if (!xbps_dictionary_set_cstring(binpkgd, "filename-sha256", sha256)) {
 			xbps_object_release(binpkgd);
-			free(sha256);
 			free(pkgver);
 			rv = EINVAL;
 			goto out;
 		}
-		free(sha256);
 		if (stat(pkg, &st) == -1) {
 			xbps_object_release(binpkgd);
 			free(pkgver);

--- a/bin/xbps-rindex/sign.c
+++ b/bin/xbps-rindex/sign.c
@@ -97,25 +97,21 @@ static bool
 rsa_sign_file(RSA *rsa, const char *file,
 	 unsigned char **sigret, unsigned int *siglen)
 {
-	unsigned char *sha256;
+	unsigned char sha256[128];
 
-	sha256 = xbps_file_hash_raw(file);
-	if(!sha256)
+	if (!xbps_file_hash_raw(sha256, sizeof(sha256), file))
 		return false;
 
 	if ((*sigret = calloc(1, RSA_size(rsa) + 1)) == NULL) {
-		free(sha256);
 		return false;
 	}
 
 	if (!RSA_sign(NID_sha1, sha256, SHA256_DIGEST_LENGTH,
 				*sigret, siglen, rsa)) {
-		free(sha256);
 		free(*sigret);
 		return false;
 	}
 
-	free(sha256);
 	return true;
 }
 

--- a/bin/xbps-uhelper/main.c
+++ b/bin/xbps-uhelper/main.c
@@ -290,14 +290,15 @@ main(int argc, char **argv)
 			usage();
 
 		for (int i = 1; i < argc; i++) {
-			filename = xbps_file_hash(argv[i]);
-			if (filename == NULL) {
+			char digest[128];
+
+			if (!xbps_file_hash(digest, sizeof(digest), argv[i])) {
 				fprintf(stderr,
 				    "E: couldn't get hash for %s (%s)\n",
 				    argv[i], strerror(errno));
 				exit(EXIT_FAILURE);
 			}
-			printf("%s\n", filename);
+			printf("%s\n", digest);
 		}
 	} else if (strcmp(argv[0], "fetch") == 0) {
 		/* Fetch a file from specified URL */

--- a/include/xbps.h.in
+++ b/include/xbps.h.in
@@ -1851,26 +1851,28 @@ char *xbps_xasprintf(const char *fmt, ...)__attribute__ ((format (printf, 1, 2))
 bool xbps_mmap_file(const char *file, void **mmf, size_t *mmflen, size_t *filelen);
 
 /**
- * Returns a string with the sha256 hash for the file specified
- * by \a file.
+ * Computes a sha256 hex digest into \a dst of size \a len
+ * from file \a file.
  *
- * @param[in] file Path to a file.
- * @return A pointer to a malloc(3)ed string, NULL otherwise and errno
- * is set appropiately. The pointer should be free(3)d when it's no
- * longer needed.
+ * @param[out] dst Destination buffer.
+ * @param[in] size of \a dst; must be at least SHA256_DIGEST_LENGTH * 2 + 1;
+ * @param[in] file The file to read.
+ *
+ * @return true on success, false otherwise.
  */
-char *xbps_file_hash(const char *file);
+bool xbps_file_hash(char *dst, size_t len, const char *file);
 
 /**
- * Returns a raw byte buffer with the sha256 hash for the file specified
- * by \a file.
+ * Computes a sha256 raw byte buffer into \a dst of size \a len
+ * from file \a file.
  *
- * @param[in] file Path to a file.
- * @return A pointer to a malloc(3)ed buffer, NULL otherwise and errno
- * is set appropiately. The pointer should be free(3)d when it's no
- * longer needed.
+ * @param[out] dst Destination buffer.
+ * @param[in] size of \a dst; must be at least SHA256_DIGEST_LENGTH.
+ * @param[in] file The file to read.
+ *
+ * @return true on success, false otherwise.
  */
-unsigned char *xbps_file_hash_raw(const char *file);
+bool xbps_file_hash_raw(unsigned char *dst, size_t len, const char *file);
 
 /**
  * Compares the sha256 hash of the file \a file with the sha256

--- a/lib/package_register.c
+++ b/lib/package_register.c
@@ -36,12 +36,12 @@ xbps_register_pkg(struct xbps_handle *xhp, xbps_dictionary_t pkgrd)
 {
 	xbps_array_t replaces;
 	xbps_dictionary_t pkgd;
-	char outstr[64], pkgname[XBPS_NAME_SIZE];
+	char outstr[64], pkgname[XBPS_NAME_SIZE], sha256[128];
 	time_t t;
 	struct tm tm;
 	struct tm *tmp;
 	const char *pkgver;
-	char *buf, *sha256;
+	char *buf;
 	int rv = 0;
 	bool autoinst = false;
 
@@ -102,9 +102,8 @@ xbps_register_pkg(struct xbps_handle *xhp, xbps_dictionary_t pkgrd)
 	 * Create a hash for the pkg's metafile if it exists.
 	 */
 	buf = xbps_xasprintf("%s/.%s-files.plist", xhp->metadir, pkgname);
-	if ((sha256 = xbps_file_hash(buf))) {
+	if (xbps_file_hash(sha256, sizeof(sha256), buf)) {
 		xbps_dictionary_set_cstring(pkgd, "metafile-sha256", sha256);
-		free(sha256);
 	}
 	free(buf);
 	/*

--- a/lib/util_hash.c
+++ b/lib/util_hash.c
@@ -153,7 +153,7 @@ xbps_file_hash(char *dst, size_t len, const char *file)
 	if (!xbps_file_hash_raw(digest, sizeof(digest), file))
 		return false;
 
-	digest2string(digest, dst, sizeof(dst));
+	digest2string(digest, dst, sizeof(digest));
 	return true;
 }
 

--- a/lib/verifysig.c
+++ b/lib/verifysig.c
@@ -137,10 +137,10 @@ bool
 xbps_verify_file_signature(struct xbps_repo *repo, const char *fname)
 {
 	char sig[PATH_MAX];
-	unsigned char *digest = NULL;
+	unsigned char digest[128];
 	bool val = false;
 
-	if (!(digest = xbps_file_hash_raw(fname))) {
+	if (!xbps_file_hash_raw(digest, sizeof(digest), fname)) {
 		xbps_dbg_printf(repo->xhp, "can't open file %s: %s\n", fname, strerror(errno));
 		return false;
 	}
@@ -148,6 +148,5 @@ xbps_verify_file_signature(struct xbps_repo *repo, const char *fname)
 	snprintf(sig, sizeof sig, "%s.sig", fname);
 	val = xbps_verify_signature(repo, sig, digest);
 
-	free(digest);
 	return val;
 }


### PR DESCRIPTION
The xbps_file_hash() and xbps_file_hash_raw() functions
have been modified to not return a heap allocation;
instead the caller must supply a buffer with enough size.

These functions now use the following prototype:

bool xbps_file_hash(char *dst, size_t len, const char *file)
bool xbps_file_hash_raw(unsigned char *dst, size_t len, const char *file)

cc @duncaen