### PR TITLE
xbps_transaction_store: ensure no multiple versions.

### DIFF
--- a/tests/xbps/libxbps/shell/incorrect_deps_test.sh
+++ b/tests/xbps/libxbps/shell/incorrect_deps_test.sh
@@ -130,10 +130,53 @@ missing_deps_body() {
 
 }
 
+atf_test_case multiple_versions
+
+multiple_versions_head() {
+	atf_set "descr" "Test for package deps: two versions of the same pkg in multiple repos"
+}
+
+multiple_versions_body() {
+	mkdir -p repo repo2 pkg_A/usr/bin pkg/usr/bin
+	touch pkg_A/usr/bin/foo
+	cd repo
+	xbps-create -A noarch -n kconfig-5.66_1 -s "kconfig" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex -d -a *.xbps
+	atf_check_equal $? 0
+	cd ../repo2
+	xbps-create -A noarch -n kconfigwidgets-1.0_1 -s "kconfigwidgets" --dependencies "kconfig>=5.60_1" ../pkg
+	atf_check_equal $? 0
+	xbps-create -A noarch -n kconfig-5.67_1 -s "kconfig" ../pkg_A
+	atf_check_equal $? 0
+	xbps-create -A noarch -n kconfig-devel-5.67_1 -s "kconfig-devel" --dependencies "kconfig>=5.67_1" ../pkg
+	atf_check_equal $? 0
+	xbps-create -A noarch -n foo-1.0_1 -s "foo" --dependencies "kconfig-devel>=5.67_1" ../pkg
+	atf_check_equal $? 0
+	xbps-rindex -d -a *.xbps
+	atf_check_equal $? 0
+	cd ..
+
+	out=$(xbps-install -r root --repo=repo --repo=repo2 -n kconfigwidgets foo|wc -l)
+	atf_check_equal $? 0
+	atf_check_equal "$out" 4
+
+	xbps-install -r root --repo=repo --repo=repo2 -yd kconfigwidgets foo
+	atf_check_equal $? 0
+
+	xbps-pkgdb -r root -a
+	atf_check_equal $? 0
+
+	out=$(xbps-query -r root -l|wc -l)
+	atf_check_equal $? 0
+	atf_check_equal "$out" 4
+}
+
 atf_init_test_cases() {
 	atf_add_test_case incorrect_dep
 	atf_add_test_case incorrect_dep_vpkg
 	atf_add_test_case incorrect_dep_issue45
 	atf_add_test_case incorrect_dep_dups
 	atf_add_test_case missing_deps
+	atf_add_test_case multiple_versions
 }


### PR DESCRIPTION
This change ensures that no multiple versions of the same pkg
are added to the transaction; if a new version of the same
package is being added as a dependency, compare stored
and current and use the greatest one.

This fixes the recent issue seen in the aarch64 builders, where
two versions of the same package were added to the transaction.

Added a new test case.