### PR TITLE
xbps_transaction_*: multiple performance improvements (v2).

### DIFF
--- a/bin/xbps-install/state_cb.c
+++ b/bin/xbps-install/state_cb.c
@@ -66,7 +66,7 @@ state_cb(const struct xbps_state_cb_data *xscd, void *cbdata UNUSED)
 		printf("[*] pkgdb upgrade in progress, please wait...\n");
 		break;
 	case XBPS_STATE_REPOSYNC:
-		printf("[*] Updating `%s' ...\n", xscd->arg);
+		printf("[*] Updating repository `%s' ...\n", xscd->arg);
 		break;
 	case XBPS_STATE_TRANS_ADDPKG:
 		if (xscd->xhp->flags & XBPS_FLAG_VERBOSE)

--- a/include/xbps.h.in
+++ b/include/xbps.h.in
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2008-2019 Juan Romero Pardines <xtraeme@gmail.com>
+ * Copyright (c) 2008-2020 Juan Romero Pardines <xtraeme@gmail.com>
  * Copyright (c) 2014-2019 Enno Boland <gottox@voidlinux.org>
  * Copyright (c) 2016-2019 Duncan Overbruck <mail@duncano.de>
  * All rights reserved.
@@ -51,7 +51,7 @@
  *
  * This header documents the full API for the XBPS Library.
  */
-#define XBPS_API_VERSION	"20200210"
+#define XBPS_API_VERSION	"20200221"
 
 #ifndef XBPS_VERSION
  #define XBPS_VERSION		"UNSET"
@@ -238,7 +238,7 @@
  * installation.
  * Must be set through the xbps_handle::flags member.
  */
-#define XBPS_FLAG_KEEP_CONFIG	0x00010000
+#define XBPS_FLAG_KEEP_CONFIG 		0x00010000
 
 /**
  * @def XBPS_FETCH_CACHECONN
@@ -285,10 +285,8 @@ extern "C" {
  * - XBPS_STATE_UKKNOWN: state hasn't been prepared or unknown error.
  * - XBPS_STATE_TRANS_DOWNLOAD: transaction is downloading binary packages.
  * - XBPS_STATE_TRANS_VERIFY: transaction is verifying binary package integrity.
- * - XBPS_STATE_TRANS_RUN: transaction is performing operations:
- * install, update, remove and replace.
- * - XBPS_STATE_TRANS_CONFIGURE: transaction is configuring all
- * unpacked packages.
+ * - XBPS_STATE_TRANS_RUN: transaction is performing operations: install, update, remove, replace.
+ * - XBPS_STATE_TRANS_CONFIGURE: transaction is configuring all unpacked packages.
  * - XBPS_STATE_TRANS_FAIL: transaction has failed.
  * - XBPS_STATE_DOWNLOAD: a binary package is being downloaded.
  * - XBPS_STATE_VERIFY: a binary package is being verified.
@@ -305,19 +303,15 @@ extern "C" {
  * - XBPS_STATE_CONFIGURE: a package is being configured.
  * - XBPS_STATE_CONFIGURE_DONE: a package has been configured successfully.
  * - XBPS_STATE_CONFIG_FILE: a package configuration file is being processed.
- * - XBPS_STATE_REPOSYNC: a remote repository's package index is being
- * synchronized.
+ * - XBPS_STATE_REPOSYNC: a remote repository's package index is being synchronized.
  * - XBPS_STATE_VERIFY_FAIL: binary package integrity has failed.
  * - XBPS_STATE_DOWNLOAD_FAIL: binary package download has failed.
  * - XBPS_STATE_REMOVE_FAIL: a package removal has failed.
  * - XBPS_STATE_REMOVE_FILE_FAIL: a package file removal has failed.
- * - XBPS_STATE_REMOVE_FILE_HASH_FAIL: a package file removal due to
- * its hash has failed.
- * - XBPS_STATE_REMOVE_FILE_OBSOLETE_FAIL: an obsolete package file
- * removal has failed.
+ * - XBPS_STATE_REMOVE_FILE_HASH_FAIL: a package file removal has failed due to hash.
+ * - XBPS_STATE_REMOVE_FILE_OBSOLETE_FAIL: an obsolete package file removal has failed.
  * - XBPS_STATE_CONFIGURE_FAIL: package configure has failed.
- * - XBPS_STATE_CONFIG_FILE_FAIL: package configuration file operation
- * has failed.
+ * - XBPS_STATE_CONFIG_FILE_FAIL: package configuration file operation has failed.
  * - XBPS_STATE_UPDATE_FAIL: package update has failed.
  * - XBPS_STATE_UNPACK_FAIL: package unpack has failed.
  * - XBPS_STATE_REPOSYNC_FAIL: syncing remote repositories has failed.
@@ -680,13 +674,9 @@ struct xbps_handle {
 	/**
 	 * @var flags
 	 *
-	 * Flags to be set globally by ORing them, possible values:
-	 *  - XBPS_FLAG_VERBOSE
-	 *  - XBPS_FLAG_FORCE_CONFIGURE
-	 *  - XBPS_FLAG_FORCE_REMOVE_FILES
-	 *  - XBPS_FLAG_DEBUG
-	 *  - XBPS_FLAG_INSTALL_AUTO
-	 *  - XBPS_FLAG_DISABLE_SYSLOG
+	 * Flags to be set globally by ORing them, possible value:
+	 *
+	 * 	- XBPS_FLAG_* (see above)
 	 */
 	int flags;
 };
@@ -1118,8 +1108,7 @@ bool xbps_match_virtual_pkg_in_dict(xbps_dictionary_t pkgd, const char *str);
  *
  * @return True if \a any virtualpkg has been matched, false otherwise.
  */
-bool xbps_match_any_virtualpkg_in_rundeps(xbps_array_t rundeps,
-					  xbps_array_t provides);
+bool xbps_match_any_virtualpkg_in_rundeps(xbps_array_t rundeps, xbps_array_t provides);
 
 /**
  * Match a package name in the specified array of strings.
@@ -1182,8 +1171,7 @@ bool xbps_match_string_in_array(xbps_array_t array, const char *val);
  * @return A proplib object iterator on success, NULL otherwise and
  * errno is set appropiately.
  */
-xbps_object_iterator_t xbps_array_iter_from_dict(xbps_dictionary_t dict,
-						 const char *key);
+xbps_object_iterator_t xbps_array_iter_from_dict(xbps_dictionary_t dict, const char *key);
 
 /*@}*/
 
@@ -1207,14 +1195,16 @@ xbps_object_iterator_t xbps_array_iter_from_dict(xbps_dictionary_t dict,
  * @retval ENOTSUP No repositories are available.
  * @retval ENXIO Package depends on invalid dependencies.
  * @retval EINVAL Any other error ocurred in the process.
+ * @retval EBUSY The xbps package must be updated.
  */
-int xbps_transaction_install_pkg(struct xbps_handle *xhp,
-				 const char *pkg,
-				 bool reinstall);
+int xbps_transaction_install_pkg(struct xbps_handle *xhp, const char *pkg, bool reinstall);
 
 /**
  * Marks a package as "going to be updated" in the transaction dictionary.
- * All repositories in the pool will be used, and newest version
+ * The first repository that contains an updated version wins.
+ *
+ * If bestmaching is enabled (see \a XBPS_FLAG_BESTMATCH),
+ * all repositories in the pool will be used, and newest version
  * available will be enqueued if it's greater than current installed
  * version.
  *
@@ -1227,6 +1217,7 @@ int xbps_transaction_install_pkg(struct xbps_handle *xhp,
  * @retval ENOTSUP No repositories are available.
  * @retval ENXIO Package depends on invalid dependencies.
  * @retval EINVAL Any other error ocurred in the process.
+ * @retval EBUSY The xbps package must be updated.
  */
 int xbps_transaction_update_pkg(struct xbps_handle *xhp, const char *pkgname);
 
@@ -1238,7 +1229,9 @@ int xbps_transaction_update_pkg(struct xbps_handle *xhp, const char *pkgname);
  * @param[in] xhp Pointer to the xbps_handle struct.
  *
  * @return 0 on success, otherwise an errno value.
- * @retval EEXIST All installed package are already up-to-date.
+ * @retval EBUSY The xbps package must be updated.
+ * @retval EEXIST All installed packages are already up-to-date.
+ * @retval EINVAL Any other error ocurred in the process.
  */
 int xbps_transaction_update_packages(struct xbps_handle *xhp);
 
@@ -1257,9 +1250,7 @@ int xbps_transaction_update_packages(struct xbps_handle *xhp);
  * @retval EINVAL
  * @retval ENXIO A problem ocurred in the process.
  */
-int xbps_transaction_remove_pkg(struct xbps_handle *xhp,
-				const char *pkgname,
-				bool recursive);
+int xbps_transaction_remove_pkg(struct xbps_handle *xhp, const char *pkgname, bool recursive);
 
 /**
  * Finds all package orphans currently installed and adds them into
@@ -1307,6 +1298,55 @@ int xbps_transaction_prepare(struct xbps_handle *xhp);
  * @return 0 on success, otherwise an errno value.
  */
 int xbps_transaction_commit(struct xbps_handle *xhp);
+
+/**
+ * @enum xbps_trans_type_t
+ *
+ * uint8_t representing the pkg transaction type in transaction dictionary.
+ *
+ *  - XBPS_TRANS_UNKNOWN: Unknown type
+ *  - XBPS_TRANS_INSTALL: pkg will be installed
+ *  - XBPS_TRANS_REINSTALL: pkg will be reinstalled
+ *  - XBPS_TRANS_UPDATE: pkg will be updated
+ *  - XBPS_TRANS_CONFIGURE: pkg will be configured
+ *  - XBPS_TRANS_REMOVE: pkg will be removed
+ *  - XBPS_TRANS_HOLD: pkg won't be updated (on hold mode)
+ *  - XBPS_TRANS_DOWNLOAD: pkg will be downloaded
+ */
+typedef enum xbps_trans_type {
+	XBPS_TRANS_UNKNOWN = 0,
+	XBPS_TRANS_INSTALL,
+	XBPS_TRANS_REINSTALL,
+	XBPS_TRANS_UPDATE,
+	XBPS_TRANS_CONFIGURE,
+	XBPS_TRANS_REMOVE,
+	XBPS_TRANS_HOLD,
+	XBPS_TRANS_DOWNLOAD
+} xbps_trans_type_t;
+
+/**
+ * Returns the transaction type associated with \a pkg_repod.
+ *
+ * See \a xbps_trans_type_t for possible values.
+ *
+ * @param[in] pkg_repod Package dictionary stored in a repository.
+ *
+ * @return The transaction type associated.
+ */
+xbps_trans_type_t xbps_transaction_pkg_type(xbps_dictionary_t pkg_repod);
+
+/**
+ * Sets the transaction type associated with \a pkg_repod.
+ *
+ * See \a xbps_trans_type_t for possible values.
+ *
+ * @param[in] pkg_repod Package dictionary stored in a repository.
+ * @param[in] type The transaction type to set.
+ *
+ * @return Returns true on success, false otherwise.
+ */
+
+bool xbps_transaction_pkg_type_set(xbps_dictionary_t pkg_repod, xbps_trans_type_t type);
 
 /*@}*/
 
@@ -1479,8 +1519,7 @@ xbps_dictionary_t xbps_rpool_get_pkg(struct xbps_handle *xhp, const char *pkg);
  * @note When returned dictionary is no longer needed, you must release it
  * with xbps_object_release(3).
  */
-xbps_dictionary_t xbps_rpool_get_virtualpkg(struct xbps_handle *xhp,
-					    const char *pkg);
+xbps_dictionary_t xbps_rpool_get_virtualpkg(struct xbps_handle *xhp, const char *pkg);
 
 /**
  * Returns a proplib array of strings with reverse dependencies of all
@@ -1666,8 +1705,7 @@ xbps_dictionary_t xbps_repo_get_pkg(struct xbps_repo *repo, const char *pkg);
  *
  * @return The pkg dictionary on success, NULL otherwise.
  */
-xbps_dictionary_t xbps_repo_get_virtualpkg(struct xbps_repo *repo,
-					     const char *pkg);
+xbps_dictionary_t xbps_repo_get_virtualpkg(struct xbps_repo *repo, const char *pkg);
 
 /**
  * Returns a pkg dictionary of the matching \a plist file from a binary package,
@@ -1767,9 +1805,7 @@ typedef enum pkg_state {
  *
  * @return 0 on success, otherwise an errno value.
  */
-int xbps_pkg_state_installed(struct xbps_handle *xhp,
-			     const char *pkgname,
-			     pkg_state_t *state);
+int xbps_pkg_state_installed(struct xbps_handle *xhp, const char *pkgname, pkg_state_t *state);
 
 /**
  * Gets package state from a package dictionary \a dict, and sets its
@@ -2117,9 +2153,7 @@ bool xbps_pkg_has_rundeps(xbps_dictionary_t dict);
  *
  * @return True on match, false otherwise.
  */
-bool xbps_pkg_arch_match(struct xbps_handle *xhp,
-			 const char *orig,
-			 const char *target);
+bool xbps_pkg_arch_match(struct xbps_handle *xhp, const char *orig, const char *target);
 
 /**
  * Converts the 64 bits signed number specified in \a bytes to
@@ -2132,6 +2166,10 @@ bool xbps_pkg_arch_match(struct xbps_handle *xhp,
  * @return A negative number is returned on error, 0 otherwise.
  */
 int xbps_humanize_number(char *buf, int64_t bytes);
+
+/**
+ * Wrappers for strlcat() and strlcpy().
+ */
 size_t xbps_strlcat(char *dest, const char *src, size_t siz);
 size_t xbps_strlcpy(char *dest, const char *src, size_t siz);
 /**
@@ -2249,8 +2287,7 @@ ssize_t xbps_path_prepend(char *dst, size_t len, const char *prefix);
  * @return The sanitized path in a buffer.
  * The returned buffer must be free(3)d when it's no longer necessary.
  */
-char *xbps_symlink_target(struct xbps_handle *xhp, const char *path,
-		const char *target);
+char *xbps_symlink_target(struct xbps_handle *xhp, const char *path, const char *target);
 
 /**
  * Returns true if any of the fnmatch patterns in \a patterns matches

--- a/include/xbps_api_impl.h
+++ b/include/xbps_api_impl.h
@@ -116,23 +116,29 @@ int HIDDEN xbps_entry_is_a_conf_file(xbps_dictionary_t, const char *);
 int HIDDEN xbps_entry_install_conf_file(struct xbps_handle *, xbps_dictionary_t,
 		xbps_dictionary_t, struct archive_entry *, const char *,
 		const char *, bool);
-int HIDDEN xbps_repository_find_deps(struct xbps_handle *, xbps_array_t,
-		xbps_dictionary_t);
 xbps_dictionary_t HIDDEN xbps_find_virtualpkg_in_conf(struct xbps_handle *,
 		xbps_dictionary_t, const char *);
 xbps_dictionary_t HIDDEN xbps_find_pkg_in_dict(xbps_dictionary_t, const char *);
 xbps_dictionary_t HIDDEN xbps_find_virtualpkg_in_dict(struct xbps_handle *,
 		xbps_dictionary_t, const char *);
 xbps_dictionary_t HIDDEN xbps_find_pkg_in_array(xbps_array_t, const char *,
-		const char *);
+		xbps_trans_type_t);
 xbps_dictionary_t HIDDEN xbps_find_virtualpkg_in_array(struct xbps_handle *,
-		xbps_array_t, const char *, const char *);
-void HIDDEN xbps_transaction_revdeps(struct xbps_handle *, xbps_array_t);
-bool HIDDEN xbps_transaction_shlibs(struct xbps_handle *, xbps_array_t,
-		xbps_array_t);
+		xbps_array_t, const char *, xbps_trans_type_t);
+
+/* transaction */
+bool HIDDEN xbps_transaction_check_revdeps(struct xbps_handle *, xbps_array_t);
+bool HIDDEN xbps_transaction_check_shlibs(struct xbps_handle *, xbps_array_t);
+bool HIDDEN xbps_transaction_check_replaces(struct xbps_handle *, xbps_array_t);
+bool HIDDEN xbps_transaction_check_conflicts(struct xbps_handle *, xbps_array_t);
+bool HIDDEN xbps_transaction_store(struct xbps_handle *, xbps_array_t, xbps_dictionary_t, bool);
 int HIDDEN xbps_transaction_init(struct xbps_handle *);
-int HIDDEN xbps_transaction_store(struct xbps_handle *, xbps_array_t,
-		xbps_dictionary_t, const char *, bool);
+int HIDDEN xbps_transaction_files(struct xbps_handle *,
+		xbps_object_iterator_t);
+int HIDDEN xbps_transaction_fetch(struct xbps_handle *,
+		xbps_object_iterator_t);
+int HIDDEN xbps_transaction_pkg_deps(struct xbps_handle *, xbps_array_t, xbps_dictionary_t);
+
 char HIDDEN *xbps_get_remote_repo_string(const char *);
 int HIDDEN xbps_repo_sync(struct xbps_handle *, const char *);
 int HIDDEN xbps_file_hash_check_dictionary(struct xbps_handle *,
@@ -143,10 +149,8 @@ void HIDDEN xbps_set_cb_fetch(struct xbps_handle *, off_t, off_t, off_t,
 int HIDDEN xbps_set_cb_state(struct xbps_handle *, xbps_state_t, int,
 		const char *, const char *, ...);
 int HIDDEN xbps_unpack_binary_pkg(struct xbps_handle *, xbps_dictionary_t);
-int HIDDEN xbps_transaction_package_replace(struct xbps_handle *, xbps_array_t);
 int HIDDEN xbps_remove_pkg(struct xbps_handle *, const char *, bool);
 int HIDDEN xbps_register_pkg(struct xbps_handle *, xbps_dictionary_t);
-void HIDDEN xbps_transaction_conflicts(struct xbps_handle *, xbps_array_t);
 char HIDDEN *xbps_archive_get_file(struct archive *, struct archive_entry *);
 xbps_dictionary_t HIDDEN xbps_archive_get_dictionary(struct archive *,
 		struct archive_entry *);
@@ -156,9 +160,5 @@ xbps_array_t HIDDEN xbps_get_pkg_fulldeptree(struct xbps_handle *,
 struct xbps_repo HIDDEN *xbps_regget_repo(struct xbps_handle *,
 		const char *);
 int HIDDEN xbps_conf_init(struct xbps_handle *);
-int HIDDEN xbps_transaction_files(struct xbps_handle *,
-		xbps_object_iterator_t);
-int HIDDEN xbps_transaction_fetch(struct xbps_handle *,
-		xbps_object_iterator_t);
 
 #endif /* !_XBPS_API_IMPL_H_ */

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -33,18 +33,18 @@ EXTOBJS = external/dewey.o external/fexec.o external/mkpath.o
 
 # libxbps
 OBJS = package_configure.o package_config_files.o package_orphans.o
-OBJS += package_remove.o package_state.o
+OBJS += package_remove.o package_state.o package_msg.o
 OBJS += package_unpack.o package_register.o package_script.o verifysig.o
-OBJS += package_msg.o transaction_shlibs.o
-OBJS += transaction_commit.o transaction_package_replace.o
-OBJS += transaction_prepare.o transaction_ops.o transaction_store.o
-OBJS += transaction_revdeps.o transaction_conflicts.o
-OBJS += transaction_files.o transaction_fetch.o
+OBJS += transaction_commit.o transaction_prepare.o
+OBJS += transaction_ops.o transaction_store.o transaction_check_replaces.o
+OBJS += transaction_check_revdeps.o transaction_check_conflicts.o
+OBJS += transaction_check_shlibs.o
+OBJS += transaction_files.o transaction_fetch.o transaction_pkg_deps.o
 OBJS += pubkey2fp.o package_fulldeptree.o
 OBJS += download.o initend.o pkgdb.o
 OBJS += plist.o plist_find.o plist_match.o archive.o
 OBJS += plist_remove.o plist_fetch.o util.o util_path.o util_hash.o
-OBJS += repo.o repo_pkgdeps.o repo_sync.o
+OBJS += repo.o repo_sync.o
 OBJS += rpool.o cb_util.o proplib_wrapper.o
 OBJS += package_alternatives.o
 OBJS += conf.o log.o

--- a/lib/package_alternatives.c
+++ b/lib/package_alternatives.c
@@ -330,8 +330,7 @@ xbps_alternatives_unregister(struct xbps_handle *xhp, xbps_dictionary_t pkgd)
 {
 	xbps_array_t allkeys;
 	xbps_dictionary_t alternatives, pkg_alternatives;
-	const char *pkgver;
-	char pkgname[XBPS_NAME_SIZE];
+	const char *pkgver, *pkgname;
 	bool update = false;
 	int rv = 0;
 
@@ -346,8 +345,7 @@ xbps_alternatives_unregister(struct xbps_handle *xhp, xbps_dictionary_t pkgd)
 		return 0;
 
 	xbps_dictionary_get_cstring_nocopy(pkgd, "pkgver", &pkgver);
-	if (!xbps_pkg_name(pkgname, sizeof(pkgname), pkgver))
-		return EINVAL;
+	xbps_dictionary_get_cstring_nocopy(pkgd, "pkgname", &pkgname);
 
 	xbps_dictionary_get_bool(pkgd, "alternatives-update", &update);
 
@@ -472,7 +470,7 @@ prune_altgroup(struct xbps_handle *xhp, xbps_dictionary_t repod,
 
 
 static void
-remove_obsoletes(struct xbps_handle *xhp, char *pkgname, const char *pkgver,
+remove_obsoletes(struct xbps_handle *xhp, const char *pkgname, const char *pkgver,
 		xbps_dictionary_t pkgdb_alts, xbps_dictionary_t repod)
 {
 	xbps_array_t allkeys;
@@ -531,8 +529,7 @@ xbps_alternatives_register(struct xbps_handle *xhp, xbps_dictionary_t pkg_repod)
 {
 	xbps_array_t allkeys;
 	xbps_dictionary_t alternatives, pkg_alternatives;
-	const char *pkgver;
-	char pkgname[XBPS_NAME_SIZE];
+	const char *pkgver, *pkgname;
 	int rv = 0;
 
 	assert(xhp);
@@ -550,8 +547,7 @@ xbps_alternatives_register(struct xbps_handle *xhp, xbps_dictionary_t pkg_repod)
 	assert(alternatives);
 
 	xbps_dictionary_get_cstring_nocopy(pkg_repod, "pkgver", &pkgver);
-	if (!xbps_pkg_name(pkgname, sizeof(pkgname), pkgver))
-		return EINVAL;
+	xbps_dictionary_get_cstring_nocopy(pkg_repod, "pkgname", &pkgname);
 
 	/*
 	 * Compare alternatives from pkgdb and repo and then remove obsolete

--- a/lib/package_fulldeptree.c
+++ b/lib/package_fulldeptree.c
@@ -144,8 +144,7 @@ ordered_depends(struct xbps_handle *xhp, xbps_dictionary_t pkgd, bool rpool,
 	xbps_array_t rdeps, provides;
 	xbps_string_t str;
 	struct item *item, *xitem;
-	const char *pkgver = NULL;
-	char pkgn[XBPS_NAME_SIZE];
+	const char *pkgver = NULL, *pkgname = NULL;
 
 	assert(xhp);
 	assert(pkgd);
@@ -153,17 +152,15 @@ ordered_depends(struct xbps_handle *xhp, xbps_dictionary_t pkgd, bool rpool,
 	rdeps = xbps_dictionary_get(pkgd, "run_depends");
 	provides = xbps_dictionary_get(pkgd, "provides");
 	xbps_dictionary_get_cstring_nocopy(pkgd, "pkgver", &pkgver);
+	xbps_dictionary_get_cstring_nocopy(pkgd, "pkgname", &pkgname);
 
-	if (!xbps_pkg_name(pkgn, sizeof(pkgn), pkgver)) {
-		abort();
-	}
-	item = lookupItem(pkgn);
+	item = lookupItem(pkgname);
 	if (item) {
 		add_deps_recursive(item, depth == 0);
 		return item;
 	}
 
-	item = addItem(rdeps, pkgn);
+	item = addItem(rdeps, pkgname);
 	item->pkgver = pkgver;
 	assert(item);
 

--- a/lib/package_orphans.c
+++ b/lib/package_orphans.c
@@ -99,7 +99,7 @@ xbps_find_pkg_orphans(struct xbps_handle *xhp, xbps_array_t orphans_user)
 					xbps_dbg_printf(xhp, " %s skipped (!automatic)\n", pkgver);
 					continue;
 				}
-				if (xbps_find_pkg_in_array(array, pkgver, NULL)) {
+				if (xbps_find_pkg_in_array(array, pkgver, 0)) {
 					xbps_dbg_printf(xhp, " %s orphan (queued)\n", pkgver);
 					continue;
 				}
@@ -117,7 +117,7 @@ xbps_find_pkg_orphans(struct xbps_handle *xhp, xbps_array_t orphans_user)
 					const char *revdepver;
 
 					xbps_array_get_cstring_nocopy(revdeps, i, &revdepver);
-					if (xbps_find_pkg_in_array(array, revdepver, NULL))
+					if (xbps_find_pkg_in_array(array, revdepver, 0))
 						cnt++;
 				}
 				if (cnt == revdepscnt) {
@@ -173,7 +173,7 @@ xbps_find_pkg_orphans(struct xbps_handle *xhp, xbps_array_t orphans_user)
 
 			cnt = 0;
 			xbps_array_get_cstring_nocopy(rdeps, x, &deppkgver);
-			if (xbps_find_pkg_in_array(array, deppkgver, NULL)) {
+			if (xbps_find_pkg_in_array(array, deppkgver, 0)) {
 				xbps_dbg_printf(xhp, " rdep %s already queued\n", deppkgver);
 				continue;
 			}
@@ -191,7 +191,7 @@ xbps_find_pkg_orphans(struct xbps_handle *xhp, xbps_array_t orphans_user)
 
 				xbps_array_get_cstring_nocopy(reqby, j, &reqbydep);
 				xbps_dbg_printf(xhp, " %s processing revdep %s\n", pkgver, reqbydep);
-				if (xbps_find_pkg_in_array(array, reqbydep, NULL))
+				if (xbps_find_pkg_in_array(array, reqbydep, 0))
 					cnt++;
 			}
 			if (cnt == reqbycnt) {

--- a/lib/package_register.c
+++ b/lib/package_register.c
@@ -36,12 +36,12 @@ xbps_register_pkg(struct xbps_handle *xhp, xbps_dictionary_t pkgrd)
 {
 	xbps_array_t replaces;
 	xbps_dictionary_t pkgd;
-	char outstr[64], pkgname[XBPS_NAME_SIZE];
 	time_t t;
 	struct tm tm;
 	struct tm *tmp;
-	const char *pkgver;
+	const char *pkgver, *pkgname;
 	char sha256[XBPS_SHA256_SIZE];
+	char outstr[64];
 	char *buf;
 	int rv = 0;
 	bool autoinst = false;
@@ -54,11 +54,7 @@ xbps_register_pkg(struct xbps_handle *xhp, xbps_dictionary_t pkgrd)
 	}
 
 	xbps_dictionary_get_cstring_nocopy(pkgd, "pkgver", &pkgver);
-	if (!xbps_pkg_name(pkgname, sizeof(pkgname), pkgver)) {
-		xbps_dbg_printf(xhp, "%s: invalid pkgname %s\n",  __func__, pkgver);
-		rv = EINVAL;
-		goto out;
-	}
+	xbps_dictionary_get_cstring_nocopy(pkgd, "pkgname", &pkgname);
 
 	if (xhp->flags & XBPS_FLAG_INSTALL_AUTO)
 		autoinst = true;

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -221,8 +221,7 @@ array_replace_dict(xbps_array_t array,
 		   bool bypattern)
 {
 	xbps_object_t obj;
-	const char *curpkgver;
-	char curpkgname[XBPS_NAME_SIZE];
+	const char *pkgver, *pkgname;
 
 	assert(xbps_object_type(array) == XBPS_TYPE_ARRAY);
 	assert(xbps_object_type(dict) == XBPS_TYPE_DICTIONARY);
@@ -230,26 +229,24 @@ array_replace_dict(xbps_array_t array,
 
 	for (unsigned int i = 0; i < xbps_array_count(array); i++) {
 		obj = xbps_array_get(array, i);
-		if (obj == NULL)
+		if (obj == NULL) {
 			continue;
+		}
+		if (!xbps_dictionary_get_cstring_nocopy(obj, "pkgver", &pkgver)) {
+			continue;
+		}
 		if (bypattern) {
 			/* pkgpattern match */
-			xbps_dictionary_get_cstring_nocopy(obj,
-			    "pkgver", &curpkgver);
-			if (xbps_pkgpattern_match(curpkgver, str)) {
-				if (!xbps_array_set(array, i, dict))
+			if (xbps_pkgpattern_match(pkgver, str)) {
+				if (!xbps_array_set(array, i, dict)) {
 					return EINVAL;
-
+				}
 				return 0;
 			}
 		} else {
 			/* pkgname match */
-			xbps_dictionary_get_cstring_nocopy(obj,
-			    "pkgver", &curpkgver);
-			if (!xbps_pkg_name(curpkgname, XBPS_NAME_SIZE, curpkgver)) {
-				abort();
-			}
-			if (strcmp(curpkgname, str) == 0) {
+			xbps_dictionary_get_cstring_nocopy(obj, "pkgname", &pkgname);
+			if (strcmp(pkgname, str) == 0) {
 				if (!xbps_array_set(array, i, dict)) {
 					return EINVAL;
 				}

--- a/lib/transaction_fetch.c
+++ b/lib/transaction_fetch.c
@@ -191,19 +191,21 @@ download_binpkg(struct xbps_handle *xhp, xbps_dictionary_t repo_pkgd)
 int
 xbps_transaction_fetch(struct xbps_handle *xhp, xbps_object_iterator_t iter)
 {
-	xbps_object_t obj;
-	const char *trans, *repoloc;
-	int rv = 0;
 	xbps_array_t fetch = NULL, verify = NULL;
+	xbps_object_t obj;
+	xbps_trans_type_t ttype;
+	const char *repoloc;
+	int rv = 0;
 	unsigned int i, n;
 
-	while ((obj = xbps_object_iterator_next(iter)) != NULL) {
-		xbps_dictionary_get_cstring_nocopy(obj, "transaction", &trans);
-		if ((strcmp(trans, "remove") == 0) ||
-		    (strcmp(trans, "hold") == 0) ||
-		    (strcmp(trans, "configure") == 0))
-			continue;
+	xbps_object_iterator_reset(iter);
 
+	while ((obj = xbps_object_iterator_next(iter)) != NULL) {
+		ttype = xbps_transaction_pkg_type(obj);
+		if (ttype == XBPS_TRANS_REMOVE || ttype == XBPS_TRANS_HOLD ||
+		    ttype == XBPS_TRANS_CONFIGURE) {
+			continue;
+		}
 		xbps_dictionary_get_cstring_nocopy(obj, "repository", &repoloc);
 
 		/*

--- a/lib/transaction_store.c
+++ b/lib/transaction_store.c
@@ -30,47 +30,50 @@
 
 #include "xbps_api_impl.h"
 
-int HIDDEN
+bool HIDDEN
 xbps_transaction_store(struct xbps_handle *xhp, xbps_array_t pkgs,
-		xbps_dictionary_t pkgrd, const char *tract, bool autoinst)
+		xbps_dictionary_t pkgrd, bool autoinst)
 {
 	xbps_dictionary_t d, pkgd;
 	xbps_array_t replaces;
-	const char *pkgver, *curpkgver, *repo;
-	char pkgname[XBPS_NAME_SIZE], *self_replaced;
+	const char *pkgver, *pkgname, *curpkgver, *repo;
+	char *self_replaced;
 	int rv;
 
+	assert(xhp);
+	assert(pkgs);
+	assert(pkgrd);
+
 	if (!xbps_dictionary_get_cstring_nocopy(pkgrd, "pkgver", &pkgver)) {
-		abort();
+		return false;
 	}
-	if (!xbps_pkg_name(pkgname, sizeof(pkgname), pkgver)) {
-		abort();
+	if (!xbps_dictionary_get_cstring_nocopy(pkgrd, "pkgname", &pkgname)) {
+		return false;
 	}
-	d = xbps_find_pkg_in_array(pkgs, pkgname, NULL);
+	d = xbps_find_pkg_in_array(pkgs, pkgname, 0);
 	if (xbps_object_type(d) == XBPS_TYPE_DICTIONARY) {
 		/* compare version stored in transaction vs current */
 		if (!xbps_dictionary_get_cstring_nocopy(d, "pkgver", &curpkgver)) {
-			abort();
+			return false;
 		}
 		rv = xbps_cmpver(pkgver, curpkgver);
 		if (rv == 0 || rv == -1) {
 			/* same version or stored version greater than current */
-			return 0;
+			return true;
 		} else {
 			/*
 			 * Current version is greater than stored,
 			 * replace stored with current.
 			 */
 			if (!xbps_remove_pkg_from_array_by_pkgver(pkgs, curpkgver)) {
-				abort();
+				return false;
 			}
-			xbps_dbg_printf(xhp, "[trans] replaced %s with %s\n",
-			    curpkgver, pkgver);
+			xbps_dbg_printf(xhp, "[trans] replaced %s with %s\n", curpkgver, pkgver);
 		}
 	}
 
 	if ((pkgd = xbps_dictionary_copy_mutable(pkgrd)) == NULL)
-		return ENOMEM;
+		return false;
 
 	/*
 	 * Add required objects into package dep's dictionary.
@@ -100,15 +103,13 @@ xbps_transaction_store(struct xbps_handle *xhp, xbps_array_t pkgs,
 	xbps_dictionary_get_cstring_nocopy(pkgd, "repository", &repo);
 
 	xbps_set_cb_state(xhp, XBPS_STATE_TRANS_ADDPKG, 0, pkgver,
-	    "Found %s (%s) in repository %s", pkgver, tract, repo);
+	    "Found %s in repository %s", pkgver, repo);
 
-	xbps_dbg_printf(xhp, "Added `%s' into the dependency list (%s)\n",
-	    pkgver, repo);
-
+	xbps_dbg_printf(xhp, "[trans] `%s' stored (%s)\n", pkgver, repo);
 	xbps_object_release(pkgd);
 
-	return 0;
+	return true;
 err:
 	xbps_object_release(pkgd);
-	return EINVAL;
+	return false;
 }

--- a/tests/xbps/libxbps/shell/hold_test.sh
+++ b/tests/xbps/libxbps/shell/hold_test.sh
@@ -26,10 +26,6 @@ downgrade_hold_body() {
 	xbps-rindex -d -a $PWD/*.xbps
 	atf_check_equal $? 0
 	cd ..
-	out=$(xbps-install -r root --repository=$PWD/repo -un)
-	set -- $out
-	exp="$1 $2 $3 $4"
-	atf_check_equal "$exp" "A-0.1_1 hold noarch $PWD/repo"
 	xbps-install -r root --repository=$PWD/repo -yuvd
 	atf_check_equal $? 0
 	out=$(xbps-query -r root -p pkgver A)

--- a/tests/xbps/libxbps/shell/update_hold_test.sh
+++ b/tests/xbps/libxbps/shell/update_hold_test.sh
@@ -26,10 +26,6 @@ update_hold_body() {
 	xbps-rindex -d -a $PWD/*.xbps
 	atf_check_equal $? 0
 	cd ..
-	out=$(xbps-install -r root --repository=$PWD/repo -un)
-	set -- $out
-	exp="$1 $2 $3 $4"
-	atf_check_equal "$exp" "A-1.1_1 hold noarch $PWD/repo"
 	xbps-install -r root --repository=$PWD/repo -yuvd
 	atf_check_equal $? 0
 	out=$(xbps-query -r root -p pkgver A)


### PR DESCRIPTION
This commit implements multiple performance improvements
to the transaction code:

- Don't process xbps_pkg_name() N times each time we access
  its package dictionary (via pkgdb or rpool), just do it once
  at xbps_pkgdb_init() time. At pkgdb init time, it just creates
  a property in pkgdb, "pkgname". At rpool time, each time a
  package is accessed, the "pkgname" string property is added.

- The package transaction dictionary contains the "transaction"
  object to know what's the pkg type. This has been changed to an
  uint8, this simplifies the logic and it's faster than checking
  a string object. See xbps_trans_type_t and xbps_transaction_pkg_type().

- Fixed the issue that was marked with XXX in transaction shlibs
  checking code. This has been fixed and improved and resources are
  now just freed as expected.

- Simplified random code all over the place, avoiding unnecessary
  allocations or operations.

- Rename some transaction files to have a better description.

This is my first rototill to the code in 2020.