### PR TITLE
xbps-{create,rindex}: use zstd by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ to handle binary packages and repositories. Some highlights:
  * Supports **multiple local/remote repositories** (HTTP/HTTPS/FTP).
  * **RSA signed remote repositories** (NEW in 0.27).
  * Supports **multiple compression formats** for repositories:
-   gzip (default), bzip2, lz4, xz, [zstd](https://github.com/facebook/zstd).
- * Supports **multiple compression formats** for binary packages:
-   zlib, bzip2, lz4, xz (default), [zstd](https://github.com/facebook/zstd).
+   gzip (zlib), bzip2, lz4, xz, [zstd](https://github.com/facebook/zstd) (default).
+ * Supports **multiple compression formats** for package archives:
+   gzip (zlib), bzip2, lz4, xz, [zstd](https://github.com/facebook/zstd) (default).
  * **SHA256 hashes** for package metadata, files and binary packages.
  * Supports **package states** (ala dpkg) to mitigate broken package
    installs/updates.

--- a/bin/xbps-create/main.c
+++ b/bin/xbps-create/main.c
@@ -105,7 +105,7 @@ usage(void)
 	"                     This expects a blank separated list of <name>:<symlink>:<target>, e.g\n"
 	"                     'vi:/usr/bin/vi:/usr/bin/vim foo:/usr/bin/foo:/usr/bin/blah'.\n"
 	" --build-options     A string with the used build options.\n"
-	" --compression       Compression format: none, gzip, bzip2, lz4, zstd, xz (default).\n"
+	" --compression       Compression format: none, gzip, bzip2, lz4, xz, zstd (default).\n"
 	" --shlib-provides    List of provided shared libraries (blank separated list,\n"
 	"                     e.g 'libfoo.so.1 libblah.so.2').\n"
 	" --shlib-requires    List of required shared libraries (blank separated list,\n"
@@ -1050,10 +1050,14 @@ main(int argc, char **argv)
 	if (ar == NULL)
 		die("cannot create new archive");
 	/*
-	 * Set compression format, xz if unset.
+	 * Set compression format, zstd by default.
 	 */
-	if (compression == NULL || strcmp(compression, "xz") == 0) {
+	if (compression == NULL || strcmp(compression, "zstd") == 0) {
+		archive_write_add_filter_zstd(ar);
+		archive_write_set_options(ar, "compression-level=9");
+	} else if (strcmp(compression, "xz") == 0) {
 		archive_write_add_filter_xz(ar);
+		archive_write_set_options(ar, "compression-level=9");
 	} else if (strcmp(compression, "gzip") == 0) {
 		archive_write_add_filter_gzip(ar);
 		archive_write_set_options(ar, "compression-level=9");
@@ -1063,9 +1067,6 @@ main(int argc, char **argv)
 	} else if (strcmp(compression, "lz4") == 0) {
 		archive_write_add_filter_lz4(ar);
 		archive_write_set_options(ar, "compression-level=9");
-	} else if (strcmp(compression, "zstd") == 0) {
-		archive_write_add_filter_zstd(ar);
-		archive_write_set_options(ar, "compression-level=19");
 	} else if (strcmp(compression, "none") == 0) {
 		/* empty */
 	} else {

--- a/bin/xbps-create/xbps-create.1
+++ b/bin/xbps-create/xbps-create.1
@@ -1,4 +1,4 @@
-.Dd June 17, 2019
+.Dd February 21, 2020
 .Dt XBPS-CREATE 1
 .Sh NAME
 .Nm xbps-create
@@ -73,7 +73,7 @@ Show the version information.
 A string containing the build options used in package.
 .It Fl -compression Ar none | gzip | bzip2 | xz | lz4 | zstd
 Set the binary package compression format. If unset, defaults to
-.Ar xz .
+.Ar zstd .
 .It Fl -shlib-provides Ar list
 A list of provided shared libraries, separated by whitespaces. Example:
 .Ar 'libfoo.so.2 libblah.so.1' .

--- a/bin/xbps-rindex/main.c
+++ b/bin/xbps-rindex/main.c
@@ -43,7 +43,7 @@ usage(bool fail)
 	    " -v --verbose                      Verbose messages\n"
 	    " -V --version                      Show XBPS version\n"
 	    " -C --hashcheck                    Consider file hashes for cleaning up packages\n"
-	    "    --compression <fmt>            Compression format: none, gzip (default), bzip2, lz4, zstd, xz.\n"
+	    "    --compression <fmt>            Compression format: none, gzip, bzip2, lz4, xz, zstd (default).\n"
 	    "    --privkey <key>                Path to the private key for signing\n"
 	    "    --signedby <string>            Signature details, i.e \"name <email>\"\n\n"
 	    "MODE\n"

--- a/bin/xbps-rindex/repoflush.c
+++ b/bin/xbps-rindex/repoflush.c
@@ -63,7 +63,13 @@ repodata_flush(struct xbps_handle *xhp, const char *repodir,
 	if (ar == NULL)
 		return false;
 
-	if (compression == NULL || strcmp(compression, "gzip") == 0) {
+	/*
+	 * Set compression format, zstd by default.
+	 */
+	if (compression == NULL || strcmp(compression, "zstd") == 0) {
+		archive_write_add_filter_zstd(ar);
+		archive_write_set_options(ar, "compression-level=9");
+	} else if (strcmp(compression, "gzip") == 0) {
 		archive_write_add_filter_gzip(ar);
 		archive_write_set_options(ar, "compression-level=9");
 	} else if (strcmp(compression, "bzip2") == 0) {
@@ -74,9 +80,7 @@ repodata_flush(struct xbps_handle *xhp, const char *repodir,
 		archive_write_set_options(ar, "compression-level=9");
 	} else if (strcmp(compression, "xz") == 0) {
 		archive_write_add_filter_xz(ar);
-	} else if (strcmp(compression, "zstd") == 0) {
-		archive_write_add_filter_zstd(ar);
-		archive_write_set_options(ar, "compression-level=19");
+		archive_write_set_options(ar, "compression-level=9");
 	} else if (strcmp(compression, "none") == 0) {
 		/* empty */
 	} else {

--- a/bin/xbps-rindex/xbps-rindex.1
+++ b/bin/xbps-rindex/xbps-rindex.1
@@ -1,4 +1,4 @@
-.Dd June 20, 2019
+.Dd February 21, 2020
 .Dt XBPS-RINDEX 1
 .Sh NAME
 .Nm xbps-rindex
@@ -19,7 +19,7 @@ in local repositories.
 Enables extra debugging shown to stderr.
 .It Fl -compression Ar none | gzip | bzip2 | xz | lz4 | zstd
 Set the repodata compression format. If unset, defaults to
-.Ar gzip .
+.Ar zstd .
 .It Fl C -hashcheck
 Check not only for file existence but for the correct file hash while cleaning.
 This flag is only useful with the


### PR DESCRIPTION
There's lots of benchmarks right there, zlib vs zstd, xz vs zstd.
Take your own conclusion.