### PR TITLE
bin: use size_t where applicable.

### DIFF
--- a/bin/xbps-install/defs.h
+++ b/bin/xbps-install/defs.h
@@ -48,8 +48,8 @@ struct transaction {
 /* from transaction.c */
 int	install_new_pkg(struct xbps_handle *, const char *, bool);
 int	update_pkg(struct xbps_handle *, const char *);
-int	dist_upgrade(struct xbps_handle *, int, bool, bool);
-int	exec_transaction(struct xbps_handle *, int, bool, bool);
+int	dist_upgrade(struct xbps_handle *, size_t, bool, bool);
+int	exec_transaction(struct xbps_handle *, size_t, bool, bool);
 
 /* from question.c */
 bool	yesno(const char *, ...);
@@ -62,8 +62,8 @@ void	fetch_file_progress_cb(const struct xbps_fetch_cb_data *, void *);
 int	state_cb(const struct xbps_state_cb_data *, void *);
 
 /* From util.c */
-void	print_package_line(const char *, int, bool);
-bool	print_trans_colmode(struct transaction *, int);
+void	print_package_line(const char *, size_t, bool);
+bool	print_trans_colmode(struct transaction *, size_t);
 int	get_maxcols(void);
 
 #endif /* !_XBPS_INSTALL_DEFS_H_ */

--- a/bin/xbps-install/transaction.c
+++ b/bin/xbps-install/transaction.c
@@ -108,7 +108,7 @@ show_actions(xbps_object_iterator_t iter)
 }
 
 static void
-show_package_list(struct transaction *trans, xbps_trans_type_t ttype, int cols)
+show_package_list(struct transaction *trans, xbps_trans_type_t ttype, size_t cols)
 {
 	xbps_dictionary_t ipkgd;
 	xbps_object_t obj;
@@ -264,7 +264,7 @@ all_pkgs_on_hold(struct transaction *trans)
 }
 
 int
-dist_upgrade(struct xbps_handle *xhp, int cols, bool yes, bool drun)
+dist_upgrade(struct xbps_handle *xhp, size_t cols, bool yes, bool drun)
 {
 	int rv = 0;
 
@@ -341,7 +341,7 @@ update_pkg(struct xbps_handle *xhp, const char *pkg)
 }
 
 int
-exec_transaction(struct xbps_handle *xhp, int maxcols, bool yes, bool drun)
+exec_transaction(struct xbps_handle *xhp, size_t maxcols, bool yes, bool drun)
 {
 	xbps_array_t array;
 	struct transaction *trans;

--- a/bin/xbps-install/util.c
+++ b/bin/xbps-install/util.c
@@ -54,9 +54,9 @@ get_maxcols(void)
 }
 
 void
-print_package_line(const char *str, int maxcols, bool reset)
+print_package_line(const char *str, size_t maxcols, bool reset)
 {
-	static int cols;
+	static size_t cols;
 	static bool first;
 
 	if (reset) {
@@ -82,7 +82,7 @@ find_longest_pkgname(struct transaction *trans)
 {
 	xbps_object_t obj;
 	const char *pkgname;
-	unsigned int len = 0, max = 0;
+	size_t len = 0, max = 0;
 
 	while ((obj = xbps_object_iterator_next(trans->iter)) != NULL) {
 		if (!xbps_dictionary_get_cstring_nocopy(obj, "pkgname", &pkgname))
@@ -96,7 +96,7 @@ find_longest_pkgname(struct transaction *trans)
 }
 
 bool
-print_trans_colmode(struct transaction *trans, int cols)
+print_trans_colmode(struct transaction *trans, size_t cols)
 {
 	xbps_dictionary_t ipkgd;
 	xbps_object_t obj;
@@ -104,8 +104,7 @@ print_trans_colmode(struct transaction *trans, int cols)
 	const char *pkgver, *pkgname, *ipkgver, *ver, *iver, *tract;
 	char size[8];
 	uint64_t dlsize = 0;
-	unsigned int x, blen, pnamelen;
-	int hdrlen;
+	size_t x, blen, pnamelen, hdrlen;
 
 	pnamelen = find_longest_pkgname(trans);
 	/* header length */

--- a/bin/xbps-query/list.c
+++ b/bin/xbps-query/list.c
@@ -33,8 +33,8 @@
 #include "defs.h"
 
 struct list_pkgver_cb {
-	int pkgver_len;
-	int maxcols;
+	size_t pkgver_len;
+	size_t maxcols;
 };
 
 int
@@ -47,7 +47,7 @@ list_pkgs_in_dict(struct xbps_handle *xhp UNUSED,
 	struct list_pkgver_cb *lpc = arg;
 	const char *pkgver = NULL, *short_desc = NULL, *state_str = NULL;
 	char tmp[255], *out = NULL;
-	int i, len = 0;
+	size_t i, len = 0;
 	pkg_state_t state;
 
 	xbps_dictionary_get_cstring_nocopy(obj, "pkgver", &pkgver);
@@ -227,7 +227,7 @@ _find_longest_pkgver_cb(struct xbps_handle *xhp UNUSED,
 {
 	struct fflongest *ffl = arg;
 	const char *pkgver = NULL;
-	unsigned int len;
+	size_t len;
 
 	xbps_dictionary_get_cstring_nocopy(obj, "pkgver", &pkgver);
 	len = strlen(pkgver);


### PR DESCRIPTION
To make sure we don't get a negative value due to overflowing.