### PR TITLE
lib/transaction_files.c: allow replacing file with alternative

### DIFF
--- a/bin/xbps-uchroot/main.c
+++ b/bin/xbps-uchroot/main.c
@@ -135,7 +135,7 @@ walk_dir(const char *path,
 	struct stat sb;
 	const char *p;
 	char tmp_path[PATH_MAX] = {0};
-	int rv, i;
+	int rv = 0, i;
 
 	i = scandir(path, &list, NULL, alphasort);
 	if (i == -1) {

--- a/include/xbps_api_impl.h
+++ b/include/xbps_api_impl.h
@@ -160,5 +160,7 @@ xbps_array_t HIDDEN xbps_get_pkg_fulldeptree(struct xbps_handle *,
 struct xbps_repo HIDDEN *xbps_regget_repo(struct xbps_handle *,
 		const char *);
 int HIDDEN xbps_conf_init(struct xbps_handle *);
+int HIDDEN xbps_parse_alternative(char *alternative, const char *rootdir,
+		char **linkpath, char **dir, char **target);
 
 #endif /* !_XBPS_API_IMPL_H_ */

--- a/lib/package_alternatives.c
+++ b/lib/package_alternatives.c
@@ -1,6 +1,7 @@
 /*-
  * Copyright (c) 2015-2019 Juan Romero Pardines.
  * Copyright (c) 2019 Duncan Overbruck.
+ * Copyright (c) 2020 Piotr Wójcik
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -153,27 +154,18 @@ create_symlinks(struct xbps_handle *xhp, xbps_array_t a, const char *grname)
 {
 	int rv;
 	unsigned int i, n;
-	char *alternative, *tok1, *tok2, *linkpath, *target, *dir, *p;
+	char *alternative, *target, *dir, *p, *linkpath;
 
 	n = xbps_array_count(a);
 
 	for (i = 0; i < n; i++) {
 		alternative = xbps_string_cstring(xbps_array_get(a, i));
+		target = linkpath = NULL;
 
-		if (!(tok1 = strtok(alternative, ":")) ||
-		    !(tok2 = strtok(NULL, ":"))) {
+		if (xbps_parse_alternative(alternative, xhp->rootdir, &linkpath, &dir, &target)) {
 			free(alternative);
 			return -1;
 		}
-
-		target = strdup(tok2);
-		dir = dirname(tok2);
-
-		/* add target dir to relative links */
-		if (tok1[0] != '/')
-			linkpath = xbps_xasprintf("%s/%s/%s", xhp->rootdir, dir, tok1);
-		else
-			linkpath = xbps_xasprintf("%s/%s", xhp->rootdir, tok1);
 
 		/* create target directory, necessary for dangling symlinks */
 		dir = xbps_xasprintf("%s/%s", xhp->rootdir, dir);
@@ -202,7 +194,7 @@ create_symlinks(struct xbps_handle *xhp, xbps_array_t a, const char *grname)
 
 		xbps_set_cb_state(xhp, XBPS_STATE_ALTGROUP_LINK_ADDED, 0, NULL,
 		    "Creating '%s' alternatives group symlink: %s -> %s",
-		    grname, tok1, target);
+		    grname, linkpath + strlen(xhp->rootdir), target);
 
 		if (target[0] == '/') {
 			p = relpath(linkpath + strlen(xhp->rootdir), target);
@@ -522,6 +514,46 @@ remove_obsoletes(struct xbps_handle *xhp, const char *pkgname, const char *pkgve
 		}
 	}
 	xbps_object_release(allkeys);
+}
+
+
+/**
+ * Computes path, parent directory and target of alternative link, based on
+ * record from index and rootdir.
+ *
+ * @param[in] alternative Alternative information from index - colon-delimited
+ * pair of relative or absolute link path and absolute target. Is passed to
+ * strtok.
+ * @param[in] rootdir Rootdir path.
+ * @param[out] linkpath Path of defined link. Starts with rootdir if it isn't
+ * NULL or empty. On success, returns memory to be freed.
+ * @param[out] dir Parent directory of linkpath. Not to be freed.
+ * @param[out] target Link target, without rootdir. On success, returns memory to
+ * be freed.
+ *
+ * @return nonzero on error, zero on success.
+ **/
+int HIDDEN
+xbps_parse_alternative(char *alternative, const char *rootdir, char **linkpath, char **dir, char **target)
+{
+	char *tok1, *tok2;
+	if (!alternative ||
+	    !(tok1 = strtok(alternative, ":")) ||
+	    !(tok2 = strtok(NULL, ":"))) {
+		return -1;
+	}
+
+	*target = strdup(tok2);
+	*dir = dirname(tok2);
+
+	/* add target dir to relative links */
+	*linkpath = xbps_xasprintf("%s%s%s%s%s",
+	    ((rootdir && *rootdir) ? rootdir : ""),
+	    ((rootdir && *rootdir) ? "/" : ""),
+	    ((tok1[0] != '/') ? *dir : ""),
+	    ((tok1[0] != '/') ? "/" : ""),
+	    tok1);
+	return 0;
 }
 
 int

--- a/tests/xbps/libxbps/shell/obsoletefiles_test.sh
+++ b/tests/xbps/libxbps/shell/obsoletefiles_test.sh
@@ -892,7 +892,6 @@ atf_test_case multiple_obsoletes_with_alternatives_unordered
 
 multiple_obsoletes_with_alternatives_unordered_head() {
 	atf_set "descr" "Multiple packages add alternative unordered"
-	atf_expect_fail "not fixed yet"
 }
 
 multiple_obsoletes_with_alternatives_unordered_body() {

--- a/tests/xbps/xbps-alternatives/main_test.sh
+++ b/tests/xbps/xbps-alternatives/main_test.sh
@@ -847,8 +847,6 @@ replace_file_with_alternative_head() {
 	atf_set "descr" "xbps-alternatives: replace file with an alternative"
 }
 replace_file_with_alternative_body() {
-	atf_expect_fail "https://github.com/void-linux/xbps/pull/185"
-
 	mkdir -p repo pkg_A_old/usr/bin pkg_A_new/usr/bin pkg_B_old/usr/bin \
 	pkg_B_new/usr/bin
 	printf 'A' > pkg_A_old/usr/bin/pkg-a-file
@@ -895,8 +893,8 @@ replace_file_with_alternative_body() {
 
 	test -L root/usr/bin/file
 	atf_check_equal $? 0
-	test "$(readlink -f root/usr/bin/file)" = "pkg-b-file"
-	atf_check_equal $? 0
+	lnk=$(readlink -f root/usr/bin/file)
+	atf_check_equal $lnk "$PWD/root/usr/bin/pkg-a-file"
 }
 
 atf_init_test_cases() {


### PR DESCRIPTION
Fix alternative-file clobber by adding alternatives to obsolete files processing. More test cases, like removing one alternative provider when other is installed and not in transaction, are already written, so not adding duplicates.

Other commit is not related to topic, just found it breaking compilation with -Og.