### PR TITLE
travis: build on bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: generic
 
+dist: bionic
+
 notifications:
   email: false
 


### PR DESCRIPTION
Change the build environment from the current travis default (xenial) to
bonic, so that we can run on a newer kernel. This gets rid of issues
related with coreutils due to the statx syscall which is unavailable on
xenial kernels.