### PR TITLE
xbps-rindex: multiple changes to validate dependencies.

### DIFF
--- a/bin/xbps-rindex/defs.h
+++ b/bin/xbps-rindex/defs.h
@@ -67,7 +67,7 @@
 #define _XBPS_RINDEX		"xbps-rindex"
 
 /* From index-add.c */
-int	index_add(struct xbps_handle *, int, int, char **, bool, const char *);
+int	index_add(struct xbps_handle *, int, int, char **, bool, bool, const char *);
 
 /* From index-clean.c */
 int	index_clean(struct xbps_handle *, const char *, bool, const char *);

--- a/include/xbps.h.in
+++ b/include/xbps.h.in
@@ -51,7 +51,7 @@
  *
  * This header documents the full API for the XBPS Library.
  */
-#define XBPS_API_VERSION	"20200221"
+#define XBPS_API_VERSION	"20200403"
 
 #ifndef XBPS_VERSION
  #define XBPS_VERSION		"UNSET"
@@ -2322,6 +2322,32 @@ xbps_plist_array_from_file(struct xbps_handle *xhp, const char *fname);
  */
 xbps_dictionary_t
 xbps_plist_dictionary_from_file(struct xbps_handle *xhp, const char *fname);
+
+/**
+ * Finds \a pkg in dictionary \d by looking at its \a pkgver string obj.
+ * The \a pkg argument is a package expression.
+ *
+ * @param[in] d Dictionary to look in.
+ * @param[in] pkg Package expression to match against \a pkgver.
+ *
+ * @return The pkg dictionary on match, NULL otherwise.
+ */
+xbps_dictionary_t
+xbps_find_pkg_in_dict(xbps_dictionary_t d, const char *pkg);
+
+/**
+ * Finds the virtual pkg \a pkg in dictionary \d by looking at
+ * its \a pkgver string obj.
+ * The \a pkg argument is a package expression. This function will match
+ * any virtual pkg found in \a d or via xbps.d(5) virtualpkg settings.
+ *
+ * @param[in] d Dictionary to look in.
+ * @param[in] pkg Package expression to match against \a pkgver.
+ *
+ * @return The pkg dictionary on match, NULL otherwise.
+ */
+xbps_dictionary_t
+xbps_find_virtualpkg_in_dict(struct xbps_handle *xhp, xbps_dictionary_t d, const char *pkg);
 
 /*@}*/
 

--- a/include/xbps_api_impl.h
+++ b/include/xbps_api_impl.h
@@ -118,9 +118,6 @@ int HIDDEN xbps_entry_install_conf_file(struct xbps_handle *, xbps_dictionary_t,
 		const char *, bool);
 xbps_dictionary_t HIDDEN xbps_find_virtualpkg_in_conf(struct xbps_handle *,
 		xbps_dictionary_t, const char *);
-xbps_dictionary_t HIDDEN xbps_find_pkg_in_dict(xbps_dictionary_t, const char *);
-xbps_dictionary_t HIDDEN xbps_find_virtualpkg_in_dict(struct xbps_handle *,
-		xbps_dictionary_t, const char *);
 xbps_dictionary_t HIDDEN xbps_find_pkg_in_array(xbps_array_t, const char *,
 		xbps_trans_type_t);
 xbps_dictionary_t HIDDEN xbps_find_virtualpkg_in_array(struct xbps_handle *,

--- a/lib/plist_find.c
+++ b/lib/plist_find.c
@@ -297,7 +297,7 @@ xbps_find_virtualpkg_in_conf(struct xbps_handle *xhp,
 	return NULL;
 }
 
-xbps_dictionary_t HIDDEN
+xbps_dictionary_t
 xbps_find_virtualpkg_in_dict(struct xbps_handle *xhp,
 			     xbps_dictionary_t d,
 			     const char *pkg)
@@ -336,7 +336,7 @@ xbps_find_virtualpkg_in_dict(struct xbps_handle *xhp,
 	return NULL;
 }
 
-xbps_dictionary_t HIDDEN
+xbps_dictionary_t
 xbps_find_pkg_in_dict(xbps_dictionary_t d, const char *pkg)
 {
 	xbps_dictionary_t pkgd = NULL;

--- a/tests/xbps/xbps-rindex/add_test.sh
+++ b/tests/xbps/xbps-rindex/add_test.sh
@@ -167,9 +167,65 @@ stage_resolve_bug_body() {
 	atf_check_equal $? 1
 }
 
+atf_test_case add_validate_deps
+
+add_validate_deps_head() {
+	atf_set "descr" "xbps-rindex(1) -a: validate deps"
+}
+
+add_validate_deps_body() {
+	mkdir -p repo pkg_A
+	cd repo
+	xbps-create -A noarch -n A-1.0_1 -s "A pkg" --dependencies "B>=0 C>=0" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex --validate -d -a $PWD/*.xbps
+	# ENODEV
+	atf_check_equal $? 19
+	xbps-create -A noarch -n B-1.1_1 -s "B pkg" ../pkg_A
+	atf_check_equal $? 0
+	xbps-create -A noarch -n C-1.1_1 -s "C pkg" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex --validate -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+	# 3 pkgs registered now
+	atf_check_equal 3 $(xbps-query --repository=repo -s ''|wc -l)
+}
+
+atf_test_case add_validate_deps_multirepo
+
+add_validate_deps_multirepo_head() {
+	atf_set "descr" "xbps-rindex(1) -a: validate deps with multiple repos"
+}
+
+add_validate_deps_multirepo_body() {
+	mkdir -p repo repo2 pkg_A
+	confdir=$(mktemp -d)
+	echo "repository=$PWD/repo" > $confdir/foo.conf
+	echo "repository=$PWD/repo2" >> $confdir/foo.conf
+	cat $confdir/foo.conf
+	cd repo2
+	xbps-create -A noarch -n B-1.1_1 -s "B pkg" ../pkg_A
+	atf_check_equal $? 0
+	xbps-create -A noarch -n C-1.1_1 -s "C pkg" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex -C $confdir --validate -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ../repo
+	xbps-create -A noarch -n A-1.0_1 -s "A pkg" --dependencies "B>=0 C>=0" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex -C $confdir --validate -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+
+	# 3 pkgs registered now
+	atf_check_equal 3 $(xbps-query -C $confdir -Rs ''|wc -l)
+	rm -rf $confdir
+}
 atf_init_test_cases() {
 	atf_add_test_case update
 	atf_add_test_case revert
 	atf_add_test_case stage
 	atf_add_test_case stage_resolve_bug
+	atf_add_test_case add_validate_deps
+	atf_add_test_case add_validate_deps_multirepo
 }


### PR DESCRIPTION
This patchset makes xbps-rindex(1) validate pkg dependencies
of all packages stored in a repository, taking into account
all repositories registered (rpool) or in current repo (if rpool
does not contain any registered repo).

This now contains some changes in its supported options:

 - Added -C/--confdir to set xbps.d configuration directory.
 - Added --validate long option to enable this behaviour with -a/--add.
 - Previous -C short option has been renamed to -H, --hashcheck.

Added two test cases to verify both behaviours: single and multirepo.

For https://github.com/void-linux/xbps/issues/259