### PR TITLE
bin/xbps-query: simplify search result printing (with truncation)

### DIFF
--- a/bin/xbps-query/list.c
+++ b/bin/xbps-query/list.c
@@ -102,7 +102,7 @@ list_manual_pkgs(struct xbps_handle *xhp UNUSED,
 	xbps_dictionary_get_bool(obj, "automatic-install", &automatic);
 	if (automatic == false) {
 		xbps_dictionary_get_cstring_nocopy(obj, "pkgver", &pkgver);
-		printf("%s\n", pkgver);
+		puts(pkgver);
 	}
 
 	return 0;
@@ -119,7 +119,7 @@ list_hold_pkgs(struct xbps_handle *xhp UNUSED,
 
 	if (xbps_dictionary_get(obj, "hold")) {
 		xbps_dictionary_get_cstring_nocopy(obj, "pkgver", &pkgver);
-		printf("%s\n", pkgver);
+		puts(pkgver);
 	}
 
 	return 0;
@@ -136,7 +136,7 @@ list_repolock_pkgs(struct xbps_handle *xhp UNUSED,
 
 	if (xbps_dictionary_get(obj, "repolock")) {
 		xbps_dictionary_get_cstring_nocopy(obj, "pkgver", &pkgver);
-		printf("%s\n", pkgver);
+		puts(pkgver);
 	}
 
 	return 0;
@@ -155,7 +155,7 @@ list_orphans(struct xbps_handle *xhp)
 	for (unsigned int i = 0; i < xbps_array_count(orphans); i++) {
 		xbps_dictionary_get_cstring_nocopy(xbps_array_get(orphans, i),
 		    "pkgver", &pkgver);
-		printf("%s\n", pkgver);
+		puts(pkgver);
 	}
 
 	return 0;

--- a/bin/xbps-query/show-deps.c
+++ b/bin/xbps-query/show-deps.c
@@ -61,7 +61,7 @@ show_pkg_deps(struct xbps_handle *xhp, const char *pkgname, bool repomode, bool 
 	for (unsigned int i = 0; i < xbps_array_count(rdeps); i++) {
 		const char *pkgdep = NULL;
 		xbps_array_get_cstring_nocopy(rdeps, i, &pkgdep);
-		printf("%s\n", pkgdep);
+		puts(pkgdep);
 	}
 	return 0;
 }
@@ -82,7 +82,7 @@ show_pkg_revdeps(struct xbps_handle *xhp, const char *pkg, bool repomode)
 
 	for (unsigned int i = 0; i < xbps_array_count(revdeps); i++) {
 		xbps_array_get_cstring_nocopy(revdeps, i, &pkgdep);
-		printf("%s\n", pkgdep);
+		puts(pkgdep);
 	}
 	xbps_object_release(revdeps);
 	return 0;


### PR DESCRIPTION
This should also fix a useless error from lgtm