### PR TITLE
xbps_register_pkg: keep stored props in pkgdb on updates.

### DIFF
--- a/tests/xbps/libxbps/shell/hold_test.sh
+++ b/tests/xbps/libxbps/shell/hold_test.sh
@@ -94,7 +94,42 @@ hold_shlibs_body() {
 	atf_check_equal $? 0
 }
 
+atf_test_case keep_on_update
+
+keep_on_update_head() {
+	atf_set "descr" "Tests for pkgs on hold: keep prop on update"
+}
+
+keep_on_update_body() {
+	mkdir -p repo pkg_A
+	cd repo
+	xbps-create -A noarch -n A-1.0_1 -s "A pkg" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+	xbps-install -r root --repository=$PWD/repo -yd A
+	atf_check_equal $? 0
+	xbps-pkgdb -r root -m hold A
+	atf_check_equal $? 0
+	out=$(xbps-query -r root -H)
+	atf_check_equal $out A-1.0_1
+	cd repo
+	xbps-create -A noarch -n A-1.1_1 -s "A pkg" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+	xbps-install -r root --repository=$PWD/repo -yuvd A
+	atf_check_equal $? 0
+	out=$(xbps-query -r root -p pkgver A)
+	atf_check_equal $out A-1.1_1
+	out=$(xbps-query -r root -p hold A)
+	atf_check_equal $out yes
+}
+
 atf_init_test_cases() {
 	atf_add_test_case downgrade_hold
 	atf_add_test_case hold_shlibs
+	atf_add_test_case keep_on_update
 }


### PR DESCRIPTION
I noticed that while updating a pkg that is on hold
or in repolock mode, does not keep those properties.

Always set those props in the new pkg dictionary to respect
this behaviour. If there's a pkg on hold and you update it,
you want to keep it in this state unless you tell it to change.

Added new test case to verify.