### PR TITLE
Perform action with pkgs on hold only if -f is set.

### DIFF
--- a/bin/xbps-install/main.c
+++ b/bin/xbps-install/main.c
@@ -155,6 +155,7 @@ main(int argc, char **argv)
 			break;
 		case 'f':
 			fflag++;
+			flags |= XBPS_FLAG_FORCE_INSTALL;
 			if (fflag > 1)
 				flags |= XBPS_FLAG_FORCE_UNPACK;
 			reinstall = true;

--- a/include/xbps.h.in
+++ b/include/xbps.h.in
@@ -51,7 +51,7 @@
  *
  * This header documents the full API for the XBPS Library.
  */
-#define XBPS_API_VERSION	"20200414"
+#define XBPS_API_VERSION	"20200422"
 
 #ifndef XBPS_VERSION
  #define XBPS_VERSION		"UNSET"
@@ -239,6 +239,14 @@
  * Must be set through the xbps_handle::flags member.
  */
 #define XBPS_FLAG_KEEP_CONFIG 		0x00010000
+
+/**
+ * @def XBPS_FLAG_FORCE_INSTALL
+ * Force installation (or reinstallation, update, downgrade)
+ * for pkgs on hold or repolock mode.
+ * Must be set through the xbps_handle::flags member.
+ */
+#define XBPS_FLAG_FORCE_INSTALL 	0x00020000
 
 /**
  * @def XBPS_FETCH_CACHECONN

--- a/tests/xbps/libxbps/shell/hold_test.sh
+++ b/tests/xbps/libxbps/shell/hold_test.sh
@@ -120,7 +120,21 @@ keep_on_update_body() {
 	xbps-rindex -d -a $PWD/*.xbps
 	atf_check_equal $? 0
 	cd ..
+	# No update because -f wasn't set
+	xbps-install -r root --repository=$PWD/repo -yuvd
+	atf_check_equal $? 0
+	out=$(xbps-query -r root -p pkgver A)
+	atf_check_equal $out A-1.0_1
+	out=$(xbps-query -r root -p hold A)
+	atf_check_equal $out yes
 	xbps-install -r root --repository=$PWD/repo -yuvd A
+	atf_check_equal $? 0
+	out=$(xbps-query -r root -p pkgver A)
+	atf_check_equal $out A-1.0_1
+	out=$(xbps-query -r root -p hold A)
+	atf_check_equal $out yes
+	# Update with -f set
+	xbps-install -r root --repository=$PWD/repo -yuvfd A
 	atf_check_equal $? 0
 	out=$(xbps-query -r root -p pkgver A)
 	atf_check_equal $out A-1.1_1


### PR DESCRIPTION
As discussed with @duncaen in #273 we've decided it's better
to only update packages on hold mode when `-f` is set.

That means that `xbps-install -u foo` won't work anymore
with pkgs on hold unless `-f` is set.

This way one could perform a full system upgrade even with
pkgs on hold via `xbps-install -fu`.

cc @duncaen