### PR TITLE
bin: use highest zstd compression level

### DIFF
--- a/bin/xbps-create/main.c
+++ b/bin/xbps-create/main.c
@@ -1052,7 +1052,7 @@ main(int argc, char **argv)
 	 */
 	if (compression == NULL || strcmp(compression, "zstd") == 0) {
 		archive_write_add_filter_zstd(ar);
-		archive_write_set_options(ar, "compression-level=9");
+		archive_write_set_options(ar, "compression-level=19");
 	} else if (strcmp(compression, "xz") == 0) {
 		archive_write_add_filter_xz(ar);
 		archive_write_set_options(ar, "compression-level=9");

--- a/bin/xbps-rindex/repoflush.c
+++ b/bin/xbps-rindex/repoflush.c
@@ -68,7 +68,7 @@ repodata_flush(struct xbps_handle *xhp, const char *repodir,
 	 */
 	if (compression == NULL || strcmp(compression, "zstd") == 0) {
 		archive_write_add_filter_zstd(ar);
-		archive_write_set_options(ar, "compression-level=9");
+		archive_write_set_options(ar, "compression-level=19");
 	} else if (strcmp(compression, "gzip") == 0) {
 		archive_write_add_filter_gzip(ar);
 		archive_write_set_options(ar, "compression-level=9");


### PR DESCRIPTION
Files are few percent smaller, decompression is still instant.