### PR TITLE
Reword cache cleaning with dry-run enabled.

### DIFF
--- a/bin/xbps-remove/clean-cache.c
+++ b/bin/xbps-remove/clean-cache.c
@@ -81,6 +81,8 @@ cleaner_cb(struct xbps_handle *xhp, xbps_object_t obj,
 	if (!drun && unlink(binpkg) == -1) {
 		fprintf(stderr, "Failed to remove `%s': %s\n",
 		    binpkg, strerror(errno));
+	} else if (drun) {
+		printf("Would remove %s from cachedir (obsolete)\n", binpkg);
 	} else {
 		printf("Removed %s from cachedir (obsolete)\n", binpkg);
 	}


### PR DESCRIPTION
Instead of incorrectly saying "Removed ${package}", rephrase to say "Would remove ${package}" when dry-run is enabled.

Based on comment https://github.com/void-linux/xbps/pull/281#issuecomment-622924113