### PR TITLE
Avoid file descriptor leakes (fix #303)

### DIFF
--- a/lib/transaction_commit.c
+++ b/lib/transaction_commit.c
@@ -105,6 +105,12 @@ xbps_transaction_commit(struct xbps_handle *xhp)
 	}
 
 	/*
+	 * After all downloads are finished, clear the connection cache
+	 * to avoid file descriptor leaks (see #303)
+	 */
+	xbps_fetch_unset_cache_connection();
+
+	/*
 	 * Collect files in the transaction and find some issues
 	 * like multiple packages installing the same file.
 	 */


### PR DESCRIPTION
HTTP connections are cached for performance, but they end up being
leaked when running configure scripts. To avoid this, close the
connection cache after all downloads are finished.