### PR TITLE
lib/Makefile: fix linking for libxbps.so.

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -78,7 +78,7 @@ $(OBJS): %.o: %.c
 
 libxbps.so: $(LIBFETCH_OBJS) $(LIBPROP_OBJS) $(OBJS)
 	@printf " [CCLD]\t\t$@\n"
-	${SILENT}$(CC) $^ $(LDFLAGS) -o $(LIBXBPS_SHLIB)
+	${SILENT}$(CC) $^ $(CFLAGS) $(LDFLAGS) -o $(LIBXBPS_SHLIB)
 	@-ln -sf $(LIBXBPS_SHLIB) libxbps.so.$(LIBXBPS_MAJOR)
 	@-ln -sf $(LIBXBPS_SHLIB) libxbps.so
 


### PR DESCRIPTION
Both CFLAGS and LDFLAGS need to be passed during linkage as CFLAGS may
contain things that influence linkage (e.g. ssp_nonshared may be
necessary to link when using strong stack protector).

Pointed out by @q66.