### PR TITLE
compat: correct HAVE_HUMANIZE_NUMBER typo

### DIFF
--- a/include/compat.h
+++ b/include/compat.h
@@ -27,7 +27,7 @@ char HIDDEN *strcasestr(const char *, const char *);
 int HIDDEN vasprintf(char **, const char *, va_list);
 #endif
 
-#ifndef HAVE_HUMANIZE_HUMBER
+#ifndef HAVE_HUMANIZE_NUMBER
 #define HN_DECIMAL              0x01
 #define HN_NOSPACE              0x02
 #define HN_B                    0x04


### PR DESCRIPTION
It should be HAVE_HUMANIZE_NUMBER instead of HAVE_HUMANIZE_HUMBER, from
the name of humanize_number(3).

It's mispelt only in this file, the configure script gets it correctly.