### PR TITLE
fetch/http: add missing case when treating status code.

### DIFF
--- a/lib/external/fetch/http.c
+++ b/lib/external/fetch/http.c
@@ -1021,6 +1021,7 @@ http_request(struct url *URL, const char *op, struct url_stat *us,
 		case HTTP_MOVED_TEMP:
 		case HTTP_SEE_OTHER:
 		case HTTP_USE_PROXY:
+		case HTTP_TEMP_REDIRECT:
 			/*
 			 * Not so fine, but we still have to read the
 			 * headers to get the new location.


### PR DESCRIPTION
The HTTP_REDIRECT() macro already included this case, but the
switch-case with the return value of http_get_reply(conn) didn't. This
made it so that a server returning HTTP_TEMP_REDIRECT (307) would
generate a failure, unless libfetch was used in verbose mode, in which
case the headers would be parsed (in order to report errors), then the
'Location' header would be found and a new connection would be made.

Fixes #348