### PR TITLE
repo: return error code if no successful mirrors

### DIFF
--- a/lib/rpool.c
+++ b/lib/rpool.c
@@ -61,6 +61,7 @@ int
 xbps_rpool_sync(struct xbps_handle *xhp, const char *uri)
 {
 	const char *repouri = NULL;
+	int repocount = 0;
 
 	for (unsigned int i = 0; i < xbps_array_count(xhp->repositories); i++) {
 		xbps_array_get_cstring_nocopy(xhp->repositories, i, &repouri);
@@ -75,7 +76,11 @@ xbps_rpool_sync(struct xbps_handle *xhp, const char *uri)
 			    xbps_fetch_error_string());
 			continue;
 		}
+		repocount++;
 	}
+
+	if(repocount == 0)
+		return -1;
 	return 0;
 }
 


### PR DESCRIPTION
Should preserve the "its okay for a mirror to fail" behavior, but still
catch in the case that it wasn't able to check any mirrors at all.

Closes #293.