### PR TITLE
Fix -Og build by generating correct compiler flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
--include config.mk
+include config.mk
 
 SUBDIRS	= include lib bin data
 

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -1,4 +1,4 @@
--include ../config.mk
+include ../config.mk
 
 SUBDIRS +=	xbps-alternatives
 SUBDIRS +=	xbps-create

--- a/bin/xbps-alternatives/Makefile
+++ b/bin/xbps-alternatives/Makefile
@@ -1,6 +1,4 @@
 TOPDIR = ../..
--include $(TOPDIR)/config.mk
-
 BIN = xbps-alternatives
 
 include $(TOPDIR)/mk/prog.mk

--- a/bin/xbps-checkvers/Makefile
+++ b/bin/xbps-checkvers/Makefile
@@ -1,6 +1,4 @@
 TOPDIR = ../..
--include $(TOPDIR)/config.mk
-
 EXTRA_CFLAGS += -Wno-deprecated-declarations
 
 BIN = xbps-checkvers

--- a/bin/xbps-create/Makefile
+++ b/bin/xbps-create/Makefile
@@ -1,6 +1,4 @@
 TOPDIR = ../..
--include $(TOPDIR)/config.mk
-
 BIN = xbps-create
 
 include $(TOPDIR)/mk/prog.mk

--- a/bin/xbps-dgraph/Makefile
+++ b/bin/xbps-dgraph/Makefile
@@ -1,6 +1,4 @@
 TOPDIR = ../..
--include $(TOPDIR)/config.mk
-
 BIN = xbps-dgraph
 
 include $(TOPDIR)/mk/prog.mk

--- a/bin/xbps-digest/Makefile
+++ b/bin/xbps-digest/Makefile
@@ -1,6 +1,4 @@
 TOPDIR = ../..
--include $(TOPDIR)/config.mk
-
 BIN = xbps-digest
 OBJS = main.o
 

--- a/bin/xbps-fbulk/Makefile
+++ b/bin/xbps-fbulk/Makefile
@@ -1,6 +1,4 @@
 TOPDIR = ../..
--include $(TOPDIR)/config.mk
-
 BIN = xbps-fbulk
 
 include $(TOPDIR)/mk/prog.mk

--- a/bin/xbps-fetch/Makefile
+++ b/bin/xbps-fetch/Makefile
@@ -1,6 +1,4 @@
 TOPDIR = ../..
--include $(TOPDIR)/config.mk
-
 BIN = xbps-fetch
 OBJS = main.o ../xbps-install/fetch_cb.o
 

--- a/bin/xbps-install/Makefile
+++ b/bin/xbps-install/Makefile
@@ -1,6 +1,4 @@
 TOPDIR = ../..
--include $(TOPDIR)/config.mk
-
 BIN = xbps-install
 OBJS = main.o transaction.o question.o fetch_cb.o state_cb.o util.o
 

--- a/bin/xbps-pkgdb/Makefile
+++ b/bin/xbps-pkgdb/Makefile
@@ -1,6 +1,4 @@
 TOPDIR = ../..
--include $(TOPDIR)/config.mk
-
 BIN =	xbps-pkgdb
 OBJS =	main.o check.o check_pkg_files.o
 OBJS +=	check_pkg_alternatives.o check_pkg_rundeps.o

--- a/bin/xbps-query/Makefile
+++ b/bin/xbps-query/Makefile
@@ -1,6 +1,4 @@
 TOPDIR = ../..
--include $(TOPDIR)/config.mk
-
 BIN = xbps-query
 OBJS =  main.o list.o show-deps.o show-info-files.o
 OBJS += ownedby.o search.o ../xbps-install/util.o

--- a/bin/xbps-reconfigure/Makefile
+++ b/bin/xbps-reconfigure/Makefile
@@ -1,6 +1,4 @@
 TOPDIR = ../..
--include $(TOPDIR)/config.mk
-
 BIN =	xbps-reconfigure
 
 include $(TOPDIR)/mk/prog.mk

--- a/bin/xbps-remove/Makefile
+++ b/bin/xbps-remove/Makefile
@@ -1,6 +1,4 @@
 TOPDIR = ../..
--include $(TOPDIR)/config.mk
-
 BIN =	xbps-remove
 OBJS =	main.o clean-cache.o
 OBJS += ../xbps-install/question.o

--- a/bin/xbps-rindex/Makefile
+++ b/bin/xbps-rindex/Makefile
@@ -1,6 +1,4 @@
 TOPDIR = ../..
--include $(TOPDIR)/config.mk
-
 BIN =	xbps-rindex
 OBJS =	main.o index-add.o index-clean.o remove-obsoletes.o repoflush.o sign.o
 

--- a/bin/xbps-uchroot/Makefile
+++ b/bin/xbps-uchroot/Makefile
@@ -1,6 +1,4 @@
 TOPDIR = ../..
--include $(TOPDIR)/config.mk
-
 BIN = xbps-uchroot
 
 include $(TOPDIR)/mk/prog.mk

--- a/bin/xbps-uhelper/Makefile
+++ b/bin/xbps-uhelper/Makefile
@@ -1,6 +1,4 @@
 TOPDIR = ../..
--include $(TOPDIR)/config.mk
-
 BIN = xbps-uhelper
 OBJS = main.o ../xbps-install/fetch_cb.o
 MAN =

--- a/bin/xbps-uunshare/Makefile
+++ b/bin/xbps-uunshare/Makefile
@@ -1,6 +1,4 @@
 TOPDIR = ../..
--include $(TOPDIR)/config.mk
-
 BIN = xbps-uunshare
 
 include $(TOPDIR)/mk/prog.mk

--- a/configure
+++ b/configure
@@ -192,11 +192,11 @@ fi
 [ -z "$DEBUG" ] && DEBUG=yes
 
 echo "CC =	$CC" >>$CONFIG_MK
-echo "CFLAGS +=	-O2" >>$CONFIG_MK
+echo "CFLAGS =	-O2" >>$CONFIG_MK
 
-echo "LDFLAGS +=  	-L\$(TOPDIR)/lib" >>$CONFIG_MK
+echo "LDFLAGS =  	-L\$(TOPDIR)/lib" >>$CONFIG_MK
 echo "CFLAGS += 	-I. -I\$(TOPDIR) -I\$(TOPDIR)/include" >>$CONFIG_MK
-echo "CPPFLAGS +=	-DXBPS_SYSCONF_PATH=\\\"${ETCDIR}\\\"" >>$CONFIG_MK
+echo "CPPFLAGS =	-DXBPS_SYSCONF_PATH=\\\"${ETCDIR}\\\"" >>$CONFIG_MK
 echo "CPPFLAGS +=	-DXBPS_SYSDEFCONF_PATH=\\\"${SHAREDIR}/xbps.d\\\"" >>$CONFIG_MK
 echo "CPPFLAGS +=	-DXBPS_VERSION=\\\"${VERSION}\\\"" >>$CONFIG_MK
 echo "CPPFLAGS +=	-DXBPS_META_PATH=\\\"${DBDIR}\\\"" >>$CONFIG_MK

--- a/data/Makefile
+++ b/data/Makefile
@@ -1,4 +1,4 @@
--include ../config.mk
+include ../config.mk
 
 PCFILE = libxbps.pc
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,4 +1,4 @@
--include ../config.mk
+include ../config.mk
 
 # Makefile to build the libxbps API documentation.
 #

--- a/include/Makefile
+++ b/include/Makefile
@@ -1,4 +1,4 @@
--include ../config.mk
+include ../config.mk
 
 INCS =	xbps.h
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,4 +1,4 @@
--include ../config.mk
+include ../config.mk
 
 RANLIB ?= ranlib
 

--- a/mk/prog.mk
+++ b/mk/prog.mk
@@ -1,4 +1,4 @@
--include $(TOPDIR)/config.mk
+include $(TOPDIR)/config.mk
 
 OBJS	?= main.o
 

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -1,4 +1,4 @@
--include $(TOPDIR)/config.mk
+include $(TOPDIR)/config.mk
 
 OBJS	?= main.o
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
--include ../config.mk
+include ../config.mk
 
 SUBDIRS = xbps
 

--- a/tests/xbps/Makefile
+++ b/tests/xbps/Makefile
@@ -1,5 +1,6 @@
--include ../../config.mk
+TOPDIR = ../..
+include $(TOPDIR)/config.mk
 
 SUBDIRS = common libxbps xbps-alternatives xbps-checkvers xbps-create xbps-install xbps-query xbps-rindex xbps-uhelper xbps-remove
 
-include ../../mk/subdir.mk
+include $(TOPDIR)/mk/subdir.mk

--- a/tests/xbps/common/Makefile
+++ b/tests/xbps/common/Makefile
@@ -1,5 +1,5 @@
 TOPDIR = ../../..
--include $(TOPDIR)/config.mk
+include $(TOPDIR)/config.mk
 
 TESTSSUBDIR = xbps
 

--- a/tests/xbps/libxbps/Makefile
+++ b/tests/xbps/libxbps/Makefile
@@ -1,4 +1,5 @@
--include ../../../config.mk
+TOPDIR = ../../..
+include $(TOPDIR)/config.mk
 
 SUBDIRS = common
 
@@ -13,4 +14,4 @@ SUBDIRS += pkgdb
 SUBDIRS += config
 SUBDIRS += shell
 
-include ../../../mk/subdir.mk
+include $(TOPDIR)/mk/subdir.mk

--- a/tests/xbps/libxbps/cmpver/Makefile
+++ b/tests/xbps/libxbps/cmpver/Makefile
@@ -1,5 +1,5 @@
 TOPDIR = ../../../..
--include $(TOPDIR)/config.mk
+include $(TOPDIR)/config.mk
 
 TESTSSUBDIR = xbps/libxbps/cmpver
 TEST = cmpver_test

--- a/tests/xbps/libxbps/common/Makefile
+++ b/tests/xbps/libxbps/common/Makefile
@@ -1,5 +1,5 @@
 TOPDIR = ../../../..
--include $(TOPDIR)/config.mk
+include $(TOPDIR)/config.mk
 
 include ../Makefile.inc
 

--- a/tests/xbps/libxbps/config/Makefile
+++ b/tests/xbps/libxbps/config/Makefile
@@ -1,5 +1,5 @@
 TOPDIR = ../../../..
--include $(TOPDIR)/config.mk
+include $(TOPDIR)/config.mk
 
 TESTSSUBDIR = xbps/libxbps/config
 TEST = config_test

--- a/tests/xbps/libxbps/find_pkg_orphans/Makefile
+++ b/tests/xbps/libxbps/find_pkg_orphans/Makefile
@@ -1,5 +1,5 @@
 TOPDIR = ../../../..
--include $(TOPDIR)/config.mk
+include $(TOPDIR)/config.mk
 
 TESTSSUBDIR = xbps/libxbps/find_pkg_orphans
 TEST = find_pkg_orphans_test

--- a/tests/xbps/libxbps/pkgdb/Makefile
+++ b/tests/xbps/libxbps/pkgdb/Makefile
@@ -1,5 +1,5 @@
 TOPDIR = ../../../..
--include $(TOPDIR)/config.mk
+include $(TOPDIR)/config.mk
 
 TESTSSUBDIR = xbps/libxbps/pkgdb
 TEST = pkgdb_test

--- a/tests/xbps/libxbps/pkgpattern_match/Makefile
+++ b/tests/xbps/libxbps/pkgpattern_match/Makefile
@@ -1,5 +1,5 @@
 TOPDIR = ../../../..
--include $(TOPDIR)/config.mk
+include $(TOPDIR)/config.mk
 
 TESTSSUBDIR = xbps/libxbps/pkgpattern_match
 TEST = pkgpattern_match_test

--- a/tests/xbps/libxbps/plist_match/Makefile
+++ b/tests/xbps/libxbps/plist_match/Makefile
@@ -1,5 +1,5 @@
 TOPDIR = ../../../..
--include $(TOPDIR)/config.mk
+include $(TOPDIR)/config.mk
 
 TESTSSUBDIR = xbps/libxbps/plist_match
 TEST = plist_match_test

--- a/tests/xbps/libxbps/plist_match_virtual/Makefile
+++ b/tests/xbps/libxbps/plist_match_virtual/Makefile
@@ -1,5 +1,5 @@
 TOPDIR = ../../../..
--include $(TOPDIR)/config.mk
+include $(TOPDIR)/config.mk
 
 TESTSSUBDIR = xbps/libxbps/plist_match_virtual
 TEST = plist_match_virtual_test

--- a/tests/xbps/libxbps/shell/Makefile
+++ b/tests/xbps/libxbps/shell/Makefile
@@ -1,5 +1,5 @@
 TOPDIR = ../../../..
--include $(TOPDIR)/config.mk
+include $(TOPDIR)/config.mk
 
 TESTSSUBDIR = xbps/libxbps/shell
 TESTSHELL = conf_files_test issue6_test issue18_test issue20_test remove_test

--- a/tests/xbps/libxbps/util/Makefile
+++ b/tests/xbps/libxbps/util/Makefile
@@ -1,5 +1,5 @@
 TOPDIR = ../../../..
--include $(TOPDIR)/config.mk
+include $(TOPDIR)/config.mk
 
 TESTSSUBDIR = xbps/libxbps/util
 TEST = util_test

--- a/tests/xbps/libxbps/util_path/Makefile
+++ b/tests/xbps/libxbps/util_path/Makefile
@@ -1,5 +1,5 @@
 TOPDIR = ../../../..
--include $(TOPDIR)/config.mk
+include $(TOPDIR)/config.mk
 
 TESTSSUBDIR = xbps/libxbps/util
 TEST = util_path_test

--- a/tests/xbps/xbps-alternatives/Makefile
+++ b/tests/xbps/xbps-alternatives/Makefile
@@ -1,5 +1,5 @@
 TOPDIR = ../../..
--include $(TOPDIR)/config.mk
+include $(TOPDIR)/config.mk
 
 TESTSHELL = main_test
 TESTSSUBDIR = xbps/xbps-alternatives

--- a/tests/xbps/xbps-checkvers/Makefile
+++ b/tests/xbps/xbps-checkvers/Makefile
@@ -1,5 +1,5 @@
 TOPDIR = ../../..
--include $(TOPDIR)/config.mk
+include $(TOPDIR)/config.mk
 
 TESTSHELL = checkvers_test
 TESTSSUBDIR = xbps/xbps-checkvers

--- a/tests/xbps/xbps-create/Makefile
+++ b/tests/xbps/xbps-create/Makefile
@@ -1,5 +1,5 @@
 TOPDIR = ../../..
--include $(TOPDIR)/config.mk
+include $(TOPDIR)/config.mk
 
 TESTSHELL = basic_test
 TESTSSUBDIR = xbps/xbps-create

--- a/tests/xbps/xbps-install/Makefile
+++ b/tests/xbps/xbps-install/Makefile
@@ -1,5 +1,5 @@
 TOPDIR = ../../..
--include $(TOPDIR)/config.mk
+include $(TOPDIR)/config.mk
 
 TESTSHELL = behaviour_tests revert_tests
 TESTSSUBDIR = xbps/xbps-install

--- a/tests/xbps/xbps-query/Makefile
+++ b/tests/xbps/xbps-query/Makefile
@@ -1,5 +1,5 @@
 TOPDIR = ../../..
--include $(TOPDIR)/config.mk
+include $(TOPDIR)/config.mk
 
 TESTSHELL = ignore_repos_test remote_test
 TESTSSUBDIR = xbps/xbps-query

--- a/tests/xbps/xbps-remove/Makefile
+++ b/tests/xbps/xbps-remove/Makefile
@@ -1,5 +1,5 @@
 TOPDIR = ../../..
--include $(TOPDIR)/config.mk
+include $(TOPDIR)/config.mk
 
 TESTSHELL = basic_test
 TESTSSUBDIR = xbps/xbps-remove

--- a/tests/xbps/xbps-rindex/Makefile
+++ b/tests/xbps/xbps-rindex/Makefile
@@ -1,5 +1,5 @@
 TOPDIR = ../../..
--include $(TOPDIR)/config.mk
+include $(TOPDIR)/config.mk
 
 TESTSHELL = add_test clean_test remove_test
 TESTSSUBDIR = xbps/xbps-rindex

--- a/tests/xbps/xbps-uhelper/Makefile
+++ b/tests/xbps/xbps-uhelper/Makefile
@@ -1,5 +1,5 @@
 TOPDIR = ../../..
--include $(TOPDIR)/config.mk
+include $(TOPDIR)/config.mk
 
 TESTSHELL = arch_test
 TESTSSUBDIR = xbps/xbps-uhelper


### PR DESCRIPTION
## Steps to reproduce:

With current master,

    export CFLAGS=-Og; make clean && ./configure && make --trace

## Expected behavior:

Build passes.

## Actual behavior:

Compilation fails because of incorrect compiler flags.

    make[2]: Entering directory '/home/piotr/github/xbps/bin/xbps-alternatives'
    gcc -DXBPS_SYSCONF_PATH=\"/usr/local/etc/xbps.d\" (cut) -Og -O2 -I. -I.. -I../include (cut) -I. -I.. -I../include (cut) -I. -I../.. -I../../include (cut) -I. -I../.. -I../../include (cut) -Og (cut)  -c main.c
    cc1: error: ../include: No such file or directory [-Werror=missing-include-dirs]
    cc1: error: ../lib/external/fetch: No such file or directory [-Werror=missing-include-dirs]
    cc1: error: ../lib/external/portableproplib: No such file or directory [-Werror=missing-include-dirs]
    cc1: error: ../lib/external/portableproplib/prop: No such file or directory [-Werror=missing-include-dirs]
    cc1: error: ../include: No such file or directory [-Werror=missing-include-dirs]
    cc1: error: ../lib/external/fetch: No such file or directory [-Werror=missing-include-dirs]
    cc1: error: ../lib/external/portableproplib: No such file or directory [-Werror=missing-include-dirs]
    cc1: error: ../lib/external/portableproplib/prop: No such file or directory [-Werror=missing-include-dirs]

Top makefile loads config.mk, then enters bin/ and loads config.mk again, what appends to previously constructed CFLAGS, then enters xbps-*, what loads config.mk again, but now with correct TOPDIR path, and appends to previous incorrect flags. Then makefile loads prog.mk, which loads config.mk again.

Fix makes config.mk to not use CFLAGS created in directories above.

In order to honor CFLAGS from environment, configure script now copies its env CFLAGS to config.mk. Flags from env in `make` step are thus ignored. This is what was likely intended, because configure script prints out own env CFLAGS. If this is correct, similar change for LDFLAGS and others should follow.

On ocassion, eliminate excessive includes, and replace `-include` directive with `include`, to make missing files early error rather than late error.

## Behavior after change

Build passes. One copy of flags from config.mk .

    gcc -DXBPS_SYSCONF_PATH=\"/usr/local/etc/xbps.d\" (cut) -O2 -I. -I../.. -I../../include (cut) -Og (cut) -c main.c
