### PR TITLE
xbps-install add -T option to skip disk space check

### DIFF
--- a/bin/xbps-install/main.c
+++ b/bin/xbps-install/main.c
@@ -53,6 +53,7 @@ usage(bool fail)
 	    " -h, --help                  Show usage\n"
 	    " -i, --ignore-conf-repos     Ignore repositories defined in xbps.d\n"
 	    " -I, --ignore-file-conflicts Ignore detected file conflicts\n"
+	    " -T, --trust-disk-space      Don't fail from insufficient disk space for transaction\n"
 	    " -U, --unpack-only           Unpack packages in transaction, do not configure them\n"
 	    " -M, --memory-sync           Remote repository data is fetched and stored\n"
 	    "                             in memory, ignoring on-disk repodata archives\n"
@@ -107,6 +108,7 @@ main(int argc, char **argv)
 		{ "help", no_argument, NULL, 'h' },
 		{ "ignore-conf-repos", no_argument, NULL, 'i' },
 		{ "ignore-file-conflicts", no_argument, NULL, 'I' },
+		{ "trust-disk-space", no_argument, NULL, 'T' },
 		{ "memory-sync", no_argument, NULL, 'M' },
 		{ "dry-run", no_argument, NULL, 'n' },
 		{ "repository", required_argument, NULL, 'R' },
@@ -182,6 +184,9 @@ main(int argc, char **argv)
 			break;
 		case 'S':
 			syncf = true;
+			break;
+		case 'T':
+			flags |= XBPS_FLAG_IGNORE_DISK_SPACE;
 			break;
 		case 'U':
 			flags |= XBPS_FLAG_UNPACK_ONLY;

--- a/include/xbps.h.in
+++ b/include/xbps.h.in
@@ -241,6 +241,13 @@
 #define XBPS_FLAG_KEEP_CONFIG 		0x00010000
 
 /**
+ * @def XBPS_FLAG_IGNORE_DISK_SPACE
+ * Skips checking disk space available and disk space needed.
+ * Must be set through the xbps_handle::flags member.
+ */
+#define XBPS_FLAG_IGNORE_DISK_SPACE	0x00020000
+
+/**
  * @def XBPS_FETCH_CACHECONN
  * Default (global) limit of cached connections used in libfetch.
  */


### PR DESCRIPTION
Add an option to trust that there is enough disk space to continue transaction. This is a workaround for #29.