### PR TITLE
xbps-install: add --verify-sig option.

### DIFF
--- a/bin/xbps-install/main.c
+++ b/bin/xbps-install/main.c
@@ -63,6 +63,7 @@ usage(bool fail)
 	    "     --reproducible          Enable reproducible mode in pkgdb\n"
 	    " -S, --sync                  Sync remote repository index\n"
 	    " -u, --update                Update target package(s)\n"
+	    "     --verify-sigs           Verify package signatures even for local repositories\n"
 	    " -v, --verbose               Verbose messages\n"
 	    " -y, --yes                   Assume yes to all questions\n"
 	    " -V, --version               Show XBPS version\n");
@@ -118,6 +119,7 @@ main(int argc, char **argv)
 		{ "version", no_argument, NULL, 'V' },
 		{ "yes", no_argument, NULL, 'y' },
 		{ "reproducible", no_argument, NULL, 1 },
+		{ "verify-sig", no_argument, NULL, 2 },
 		{ NULL, 0, NULL, 0 }
 	};
 	struct xbps_handle xh;
@@ -137,6 +139,9 @@ main(int argc, char **argv)
 		switch (c) {
 		case 1:
 			flags |= XBPS_FLAG_INSTALL_REPRO;
+			break;
+		case 2:
+			flags |= XBPS_FLAG_VERIFY_LOCAL_REPO;
 			break;
 		case 'A':
 			flags |= XBPS_FLAG_INSTALL_AUTO;

--- a/include/xbps.h.in
+++ b/include/xbps.h.in
@@ -241,6 +241,13 @@
 #define XBPS_FLAG_KEEP_CONFIG 		0x00010000
 
 /**
+ * @def XBPS_FLAG_VERIFY_LOCAL_REPO
+ * Verify package signatures even for local repositories.
+ * Must be set through the xbps_handle::flags member.
+ */
+#define XBPS_FLAG_VERIFY_LOCAL_REPO 	0x00020000
+
+/**
  * @def XBPS_FETCH_CACHECONN
  * Default (global) limit of cached connections used in libfetch.
  */


### PR DESCRIPTION
Forcing signature verification for local packages can be useful for
innumerous reasons, the simplest one being the possibility of adding a
test suite for this part of the code without requiring a test setup
running a server or similar.

For this, it was necessary to add a new flag value to xbps_handle, and I
took the opportunity to re-organize the code a bit, including always
checking sha256 for all packages and reporting when remove(3) fails.

Somewhat WIP, lacks man page docs. But it works :)