### PR TITLE
remove anything mtime related

### DIFF
--- a/bin/xbps-create/main.c
+++ b/bin/xbps-create/main.c
@@ -53,7 +53,6 @@
 
 struct xentry {
 	TAILQ_ENTRY(xentry) entries;
-	uint64_t mtime;
 	uint64_t size;
 	char *file, *type, *target;
 	char sha256[XBPS_SHA256_SIZE];
@@ -362,10 +361,7 @@ ftw_cb(const char *fpath, const struct stat *sb, const struct dirent *dir UNUSED
 		xbps_dictionary_set_cstring_nocopy(fileinfo, "type", "links");
 		xe->type = strdup("links");
 		assert(xe->type);
-		/* store modification time for regular files and links */
 		xbps_dictionary_set_cstring_nocopy(fileinfo, "type", "links");
-		xe->mtime = (uint64_t)sb->st_mtime;
-		xbps_dictionary_set_uint64(fileinfo, "mtime", (uint64_t)sb->st_mtime);
 		buf = malloc(sb->st_size+1);
 		assert(buf);
 		r = readlink(fpath, buf, sb->st_size+1);
@@ -483,9 +479,6 @@ ftw_cb(const char *fpath, const struct stat *sb, const struct dirent *dir UNUSED
 
 		xbps_dictionary_set_uint64(fileinfo, "inode", sb->st_ino);
 		xe->inode = sb->st_ino;
-		/* store modification time for regular files and links */
-		xbps_dictionary_set_uint64(fileinfo, "mtime", sb->st_mtime);
-		xe->mtime = (uint64_t)sb->st_mtime;
 		xe->size = (uint64_t)sb->st_size;
 
 	} else if (S_ISDIR(sb->st_mode)) {
@@ -603,8 +596,6 @@ process_xentry(const char *key, const char *mutable_files)
 			xbps_dictionary_set_cstring(d, "target", xe->target);
 		if (*xe->sha256)
 			xbps_dictionary_set_cstring(d, "sha256", xe->sha256);
-		if (xe->mtime)
-			xbps_dictionary_set_uint64(d, "mtime", xe->mtime);
 		if (xe->size)
 			xbps_dictionary_set_uint64(d, "size", xe->size);
 

--- a/bin/xbps-pkgdb/check_pkg_files.c
+++ b/bin/xbps-pkgdb/check_pkg_files.c
@@ -47,33 +47,6 @@
  *
  * Return 0 if test ran successfully, 1 otherwise and -1 on error.
  */
-static bool
-check_file_mtime(xbps_dictionary_t d, const char *pkg, const char *path)
-{
-	struct stat sb;
-	uint64_t mtime = 0;
-	const char *file = NULL;
-
-	/* if obj is not there, skip silently */
-	if (!xbps_dictionary_get_uint64(d, "mtime", &mtime))
-		return false;
-
-	/* if file is mutable, we don't care if it does not match */
-	if (xbps_dictionary_get(d, "mutable"))
-		return false;
-
-	if (stat(path, &sb) == -1)
-		return true;
-
-	if ((uint64_t)sb.st_mtime != mtime) {
-		xbps_dictionary_get_cstring_nocopy(d, "file", &file);
-		xbps_error_printf("%s: %s mtime mismatch "
-		    "(current: %ju, stored %ju)\n",
-		    pkg, file, (uint64_t)sb.st_mtime, mtime);
-		return true;
-	}
-	return false;
-}
 
 int
 check_pkg_files(struct xbps_handle *xhp, const char *pkgname, void *arg)
@@ -104,9 +77,6 @@ check_pkg_files(struct xbps_handle *xhp, const char *pkgname, void *arg)
 			rv = xbps_file_sha256_check(path, sha256);
 			switch (rv) {
 			case 0:
-				if (check_file_mtime(obj, pkgname, path)) {
-					test_broken = true;
-				}
 				free(path);
 				break;
 			case ENOENT:

--- a/lib/package_unpack.c
+++ b/lib/package_unpack.c
@@ -456,33 +456,6 @@ unpack_archive(struct xbps_handle *xhp,
 			    "mode to %s.\n", pkgver, entry_pname,
 			    archive_entry_strmode(entry));
 		}
-		/*
-		 * Check if current file mtime differs from archive entry
-		 * in binpkg and apply mtime if true.
-		 */
-		if (!force && file_exists && skip_extract &&
-		    (archive_entry_mtime_nsec(entry) != st.st_mtime)) {
-			struct timespec ts[2];
-
-			ts[0].tv_sec = archive_entry_atime(entry);
-			ts[0].tv_nsec = archive_entry_atime_nsec(entry);
-			ts[1].tv_sec = archive_entry_mtime(entry);
-			ts[1].tv_nsec = archive_entry_mtime_nsec(entry);
-
-			if (utimensat(AT_FDCWD, entry_pname, ts,
-				      AT_SYMLINK_NOFOLLOW) == -1) {
-				xbps_dbg_printf(xhp,
-				    "%s: failed "
-				    "to set mtime %lu to %s: %s\n",
-				    pkgver, archive_entry_mtime_nsec(entry),
-				    entry_pname,
-				    strerror(errno));
-				rv = EINVAL;
-				goto out;
-			}
-			xbps_dbg_printf(xhp, "%s: updated file timestamps to %s\n",
-			    pkgver, entry_pname);
-		}
 		if (!force && skip_extract) {
 			archive_read_data_skip(ar);
 			continue;


### PR DESCRIPTION
We don't rely on mtime anymore to detect files moved between packages, and mtime on fat filesystems is truncated by 2 seconds resulting in useless `xbps-pkgdb` warnings as seen in https://github.com/void-linux/xbps/issues/387.