### PR TITLE
hold fixes

### DIFF
--- a/lib/transaction_pkg_deps.c
+++ b/lib/transaction_pkg_deps.c
@@ -186,9 +186,12 @@ repo_deps(struct xbps_handle *xhp,
 		 */
 		if ((curpkgd = xbps_find_pkg_in_array(pkgs, reqpkg, 0)) ||
 		    (curpkgd = xbps_find_virtualpkg_in_array(xhp, pkgs, reqpkg, 0))) {
+			xbps_trans_type_t ttype_q = xbps_transaction_pkg_type(curpkgd);
 			xbps_dictionary_get_cstring_nocopy(curpkgd, "pkgver", &pkgver_q);
-			xbps_dbg_printf_append(xhp, " (%s queued)\n", pkgver_q);
-			continue;
+			if (ttype_q != XBPS_TRANS_REMOVE && ttype_q != XBPS_TRANS_HOLD) {
+				xbps_dbg_printf_append(xhp, " (%s queued %d)\n", pkgver_q, ttype_q);
+				continue;
+			}
 		}
 		/*
 		 * Pass 3: check if required dependency is already installed

--- a/tests/xbps/libxbps/shell/update_hold_test.sh
+++ b/tests/xbps/libxbps/shell/update_hold_test.sh
@@ -101,7 +101,144 @@ update_pkg_with_held_dep_body() {
 	atf_check_equal $? 0
 }
 
+atf_test_case hold_update_revdep
+
+hold_update_revdep_head() {
+	atf_set "descr" "Tests for pkgs on hold: update package with revdep on hold package"
+}
+
+hold_update_revdep_body() {
+	mkdir -p repo empty
+	cd repo
+	xbps-create -A noarch -n pari-2.11.4_1 -s "pari pkg" ../empty
+	xbps-create -A noarch -n pari-devel-2.11.4_1 --dependencies="pari>=2.11.4_1" -s "pari-devel pkg" ../empty
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -r root --repository=$PWD/repo -yd pari pari-devel
+	atf_check_equal $? 0
+
+	xbps-pkgdb -r root -m hold pari
+	atf_check_equal $? 0
+
+	cd repo
+	xbps-create -A noarch -n pari-devel-2.13.1_1 --dependencies="pari>=2.13.1_1" -s "pari-devel pkg" ../empty
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -r root --repository=$PWD/repo -dvyu
+	atf_check_equal $? 19
+}
+
+atf_test_case update_hold_update_revdep
+
+update_hold_update_revdep_head() {
+	atf_set "descr" "Tests for pkgs on hold: updateable held package and update package with revdep on held package"
+}
+
+update_hold_update_revdep_body() {
+	mkdir -p repo empty
+	cd repo
+	xbps-create -A noarch -n pari-2.11.4_1 -s "pari pkg" ../empty
+	xbps-create -A noarch -n pari-devel-2.11.4_1 --dependencies="pari>=2.11.4_1" -s "pari-devel pkg" ../empty
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -r root --repository=$PWD/repo -yd pari pari-devel
+	atf_check_equal $? 0
+
+	xbps-pkgdb -r root -m hold pari
+	atf_check_equal $? 0
+
+	cd repo
+	xbps-create -A noarch -n pari-2.13.1_1 -s "pari pkg" ../empty
+	xbps-create -A noarch -n pari-devel-2.13.1_1 --dependencies="pari>=2.13.1_1" -s "pari-devel pkg" ../empty
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -r root --repository=$PWD/repo -dvyu
+	atf_check_equal $? 19
+}
+
+atf_test_case hold_install_revdep
+
+hold_install_revdep_head() {
+	atf_set "descr" "Tests for pkgs on hold: install package with revdep on held package"
+}
+
+hold_install_revdep_body() {
+	mkdir -p repo empty
+	cd repo
+	xbps-create -A noarch -n pari-2.11.4_1 -s "pari pkg" ../empty
+	xbps-create -A noarch -n pari-devel-2.11.4_1 --dependencies="pari>=2.11.4_1" -s "pari-devel pkg" ../empty
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -r root --repository=$PWD/repo -yd pari
+	atf_check_equal $? 0
+
+	xbps-pkgdb -r root -m hold pari
+	atf_check_equal $? 0
+
+	cd repo
+	xbps-create -A noarch -n pari-devel-2.13.1_1 --dependencies="pari>=2.13.1_1" -s "pari-devel pkg" ../empty
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -r root --repository=$PWD/repo -dvy pari-devel
+	atf_check_equal $? 19
+}
+
+atf_test_case update_hold_install_revdep
+
+update_hold_install_revdep_head() {
+	atf_set "descr" "Tests for pkgs on hold: updatable held package and install package with revdep on it"
+}
+
+update_hold_install_revdep_body() {
+	mkdir -p repo empty
+	cd repo
+	xbps-create -A noarch -n pari-2.11.4_1 -s "pari pkg" ../empty
+	xbps-create -A noarch -n pari-devel-2.11.4_1 --dependencies="pari>=2.11.4_1" -s "pari-devel pkg" ../empty
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -r root --repository=$PWD/repo -yd pari
+	atf_check_equal $? 0
+
+	xbps-pkgdb -r root -m hold pari
+	atf_check_equal $? 0
+
+	cd repo
+	xbps-create -A noarch -n pari-devel-2.13.1_1 --dependencies="pari>=2.13.1_1" -s "pari-devel pkg" ../empty
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -r root --repository=$PWD/repo -dvy pari-devel
+	atf_check_equal $? 19
+}
+
 atf_init_test_cases() {
 	atf_add_test_case update_hold
 	atf_add_test_case update_pkg_with_held_dep
+	atf_add_test_case hold_update_revdep
+	atf_add_test_case update_hold_update_revdep
+	atf_add_test_case hold_install_revdep
+	atf_add_test_case update_hold_install_revdep
 }

--- a/tests/xbps/libxbps/shell/update_hold_test.sh
+++ b/tests/xbps/libxbps/shell/update_hold_test.sh
@@ -40,6 +40,8 @@ update_pkg_with_held_dep_head() {
 }
 
 update_pkg_with_held_dep_body() {
+	atf_expect_fail "this test case makes no sense"
+
 	mkdir -p some_repo pkginst pkgheld pkgdep-21_1 pkgdep-22_1
 	touch pkginst/pi00
 	touch pkgheld/ph00


### PR DESCRIPTION
This feels more like a workaround, not sure if I get it right.
At least all tests, except one that to me doesn't make a lot of sense pass.
The failing test expects the install to work, but now the install will fail.


Here is the failing `xbps-install` from the now failing test: 
```
[DEBUG] XBPS: 0.60 API: 20200423 GIT: 46758bf7
[DEBUG] Processing configuration directory: /tmp/kyua.Jp45ok/2/work/some_repo/root/empty.conf
[DEBUG] Processing system configuration directory: /tmp/kyua.Jp45ok/2/work/some_repo/root/usr/local/share/xbps.d
[DEBUG] rootdir=/tmp/kyua.Jp45ok/2/work/some_repo/root
[DEBUG] metadir=/tmp/kyua.Jp45ok/2/work/some_repo/root/var/db/xbps
[DEBUG] cachedir=/tmp/kyua.Jp45ok/2/work/some_repo/root/var/cache/xbps
[DEBUG] confdir=/tmp/kyua.Jp45ok/2/work/some_repo/root/empty.conf
[DEBUG] sysconfdir=/tmp/kyua.Jp45ok/2/work/some_repo/root/usr/local/share/xbps.d
[DEBUG] syslog=true
[DEBUG] bestmatching=false
[DEBUG] keepconf=false
[DEBUG] Architecture: x86_64
[DEBUG] Target Architecture: (null)
[DEBUG] Repository[0]=/tmp/kyua.Jp45ok/2/work/some_repo
[DEBUG] [pkgdb] added vpkg pkgdep-21_1 for pkgheld
[DEBUG] [pkgdb] initialized ok.
[DEBUG] [rpool] checking `/tmp/kyua.Jp45ok/2/work/some_repo' at index 0
[DEBUG] [repo] `/tmp/kyua.Jp45ok/2/work/some_repo/x86_64-stagedata' open stagedata No such file or directory
[DEBUG] [rpool] `/tmp/kyua.Jp45ok/2/work/some_repo' registered.
[DEBUG] xbps_repo_get_pkg: found pkginst-1.0_1
[DEBUG] [trans] `pkginst-1.0_1' stored (/tmp/kyua.Jp45ok/2/work/some_repo)
[DEBUG] xbps_transaction_install_pkg: trans_find_pkg pkginst: 0
[DEBUG] xbps_transaction_prepare: processing deps
[DEBUG] Finding required dependencies for 'pkginst-1.0_1':
[DEBUG] pkginst-1.0_1: requires dependency 'pkgdep-22_1': [DEBUG] vpkg_user_conf: vpkg_conf pkgdep-21_1 pkg pkgheld vpkgname pkgdep
[DEBUG] vpkg_user_conf: vpkg_conf pkgdep-21_1 pkg pkgheld vpkgname pkgdep
not installed `pkgheld-1.17.4_2 (vpkg)' on hold state! ignoring package.
[DEBUG] `pkgdep-22_1' added into the missing deps array.
[DEBUG] xbps_transaction_prepare: checking on hold pkgs
[DEBUG] xbps_transaction_prepare: checking replaces
[DEBUG] xbps_transaction_prepare: checking revdeps
MISSING: pkgdep-22_1
Transaction aborted due to unresolved dependencies.
[DEBUG] xbps_pkgdb_unlock: pkgdb_fd 3
[DEBUG] [pkgdb] released ok.
libxbps/shell/update_hold_test:update_pkg_with_held_dep  ->  expected_failure: this test case makes no sense: 19 != 0 (19 != 0)
kyua: E: No previous results file found for test suite result.db.
```

And here is the output prior to breaking the test:
```
[DEBUG] XBPS: 0.60 API: 20200423 GIT: 46758bf7
[DEBUG] Processing configuration directory: /tmp/kyua.U9waip/2/work/some_repo/root/empty.conf
[DEBUG] Processing system configuration directory: /tmp/kyua.U9waip/2/work/some_repo/root/usr/local/share/xbps.d
[DEBUG] rootdir=/tmp/kyua.U9waip/2/work/some_repo/root
[DEBUG] metadir=/tmp/kyua.U9waip/2/work/some_repo/root/var/db/xbps
[DEBUG] cachedir=/tmp/kyua.U9waip/2/work/some_repo/root/var/cache/xbps
[DEBUG] confdir=/tmp/kyua.U9waip/2/work/some_repo/root/empty.conf
[DEBUG] sysconfdir=/tmp/kyua.U9waip/2/work/some_repo/root/usr/local/share/xbps.d
[DEBUG] syslog=true
[DEBUG] bestmatching=false
[DEBUG] keepconf=false
[DEBUG] Architecture: x86_64
[DEBUG] Target Architecture: (null)
[DEBUG] Repository[0]=/tmp/kyua.U9waip/2/work/some_repo
[DEBUG] [pkgdb] added vpkg pkgdep-21_1 for pkgheld
[DEBUG] [pkgdb] initialized ok.
[DEBUG] [rpool] checking `/tmp/kyua.U9waip/2/work/some_repo' at index 0
[DEBUG] [repo] `/tmp/kyua.U9waip/2/work/some_repo/x86_64-stagedata' open stagedata No such file or directory
[DEBUG] [rpool] `/tmp/kyua.U9waip/2/work/some_repo' registered.
[DEBUG] xbps_repo_get_pkg: found pkginst-1.0_1
[DEBUG] [trans] `pkginst-1.0_1' stored (/tmp/kyua.U9waip/2/work/some_repo)
[DEBUG] xbps_transaction_install_pkg: trans_find_pkg pkginst: 0
[DEBUG] xbps_transaction_prepare: processing deps
[DEBUG] Finding required dependencies for 'pkginst-1.0_1':
[DEBUG] pkginst-1.0_1: requires dependency 'pkgdep-22_1': [DEBUG] vpkg_user_conf: vpkg_conf pkgdep-21_1 pkg pkgheld vpkgname pkgdep
[DEBUG] vpkg_user_conf: vpkg_conf pkgdep-21_1 pkg pkgheld vpkgname pkgdep
not installed `pkgheld-1.17.4_2 (vpkg)' on hold state! ignoring package.
[DEBUG] pkginst-1.0_1 on hold state! ignoring package.
[DEBUG] xbps_transaction_prepare: checking on hold pkgs
[DEBUG] xbps_transaction_prepare: checking replaces
[DEBUG] xbps_transaction_prepare: checking revdeps
[DEBUG] xbps_transaction_prepare: checking conflicts
[DEBUG] xbps_transaction_prepare: checking shlibs
[DEBUG] xbps_transaction_prepare: computing stats
[DEBUG] [trans] verifying 1 packages.
[DEBUG] pkginst-1.0_1: state 1 rv 0
[DEBUG] xbps_pkgdb_unlock: pkgdb_fd 3
[DEBUG] [pkgdb] released ok.
libxbps/shell/update_hold_test:update_pkg_with_held_dep  ->  passed
kyua: E: No previous results file found for test suite result.db.
```

Whats wrong with this to me is that it tests installing `pkginst` and with a missing dep.