### PR TITLE
bin/xbps-checkvers: add -X flag to check and skip removed packages with existing revdeps

### DIFF
--- a/bin/xbps-checkvers/main.c
+++ b/bin/xbps-checkvers/main.c
@@ -523,6 +523,9 @@ rcv_printf(rcv_t *rcv, FILE *fp, const char *pkgname, const char *repover,
 			p = strchr(rcv->fname, '/');
 			fwrite(rcv->fname, p ? (size_t)(p - rcv->fname) : strlen(rcv->fname), 1, fp);
 			break;
+		default:
+			fprintf(stderr, "ERROR: invalid format string\n");
+			exit(EXIT_FAILURE);
 		}
 	}
 	fputc('\n', fp);


### PR DESCRIPTION
This should make the list of removed packages safer to use by skipping removals of packages with existing revdeps.

In the x86_64 repo is currently one package which would be skipped, showing that it works.

```
$ ./bin/xbps-checkvers/xbps-checkvers -d -eX >/dev/null
skipping: libprotobuf22-32bit: protobuf-devel-32bit-3.11.4_1 depends on it
skipping: libprotobuf22-lite-32bit: protobuf-devel-32bit-3.11.4_1 depends on it
```

The  package (`protobuf-devel-32bit-3.11.4_1`) needs manual intervention, or some more logic in `xbps-checkvers` to notice that it should be removed (it was automatically generated, so there is no symlink, but since it was changed to a transitional package, the new `-32bit` package is not generated anymore).