### PR TITLE
xbps-checkvers: list installed subpackages

### DIFF
--- a/bin/xbps-checkvers/main.c
+++ b/bin/xbps-checkvers/main.c
@@ -636,7 +636,7 @@ rcv_process_dir(rcv_t *rcv, rcv_proc_func process)
 		if (rcv->show_removed)
 			xbps_dictionary_set_bool(rcv->templates, result->d_name, true);
 
-		if (S_ISLNK(st.st_mode) != 0)
+		if (S_ISLNK(st.st_mode) != 0 && !rcv->installed)
 			continue;
 
 		snprintf(filename, sizeof(filename), "%s/template", result->d_name);


### PR DESCRIPTION
Subpackages without main package installed wasn't reported
at all. This can produce duplicates in output, but checkvers'
output isn't good to loop over without passing through
./xbps-src sort-dependencies anyway.

Reported in https://github.com/void-linux/void-packages/issues/30704