### PR TITLE
drop libarchive compat and don't use deprecated functions

### DIFF
--- a/bin/xbps-create/main.c
+++ b/bin/xbps-create/main.c
@@ -647,7 +647,7 @@ write_entry(struct archive *ar, struct archive_entry *entry)
 	if ((target = archive_entry_pathname(entry)) == NULL)
 		return;
 
-	if (archive_write_header(ar, entry))
+	if (archive_write_header(ar, entry) != ARCHIVE_OK)
 		die_archive(ar, "cannot write %s to archive:", target);
 
 	/* Only regular files can have data. */

--- a/bin/xbps-rindex/defs.h
+++ b/bin/xbps-rindex/defs.h
@@ -28,38 +28,6 @@
 
 #include <xbps.h>
 
-/* libarchive compat */
-#if ARCHIVE_VERSION_NUMBER >= 3000000
-
-#define archive_read_support_compression_gzip(x) \
-	archive_read_support_filter_gzip(x)
-
-#define archive_read_support_compression_bzip2(x) \
-	archive_read_support_filter_bzip2(x)
-
-#define archive_read_support_compression_xz(x) \
-	archive_read_support_filter_xz(x)
-
-#define archive_write_set_compression_gzip(x) \
-	archive_write_add_filter_gzip(x)
-
-#define archive_write_set_compression_bzip2(x) \
-	archive_write_add_filter_bzip2(x)
-
-#define archive_write_set_compression_xz(x) \
-	archive_write_add_filter_xz(x)
-
-#define archive_read_finish(x) \
-	archive_read_free(x)
-
-#define archive_write_finish(x) \
-	archive_write_free(x)
-
-#define archive_compression_name(x) \
-	archive_filter_name(x, 0)
-
-#endif
-
 #define _XBPS_RINDEX		"xbps-rindex"
 
 /* From index-add.c */

--- a/include/xbps_api_impl.h
+++ b/include/xbps_api_impl.h
@@ -56,41 +56,6 @@
 #define __UNCONST(a)	((void *)(uintptr_t)(const void *)(a))
 #endif
 
-/* libarchive compat */
-#if ARCHIVE_VERSION_NUMBER >= 3000000
-
-#define archive_read_support_compression_all(x) \
-	archive_read_support_filter_all(x)
-
-#define archive_read_support_compression_gzip(x) \
-	archive_read_support_filter_gzip(x)
-
-#define archive_read_support_compression_bzip2(x) \
-	archive_read_support_filter_bzip2(x)
-
-#define archive_read_support_compression_xz(x) \
-	archive_read_support_filter_xz(x)
-
-#define archive_write_set_compression_gzip(x) \
-	archive_write_add_filter_gzip(x)
-
-#define archive_write_set_compression_bzip2(x) \
-	archive_write_add_filter_bzip2(x)
-
-#define archive_write_set_compression_xz(x) \
-	archive_write_add_filter_xz(x)
-
-#define archive_read_finish(x) \
-	archive_read_free(x)
-
-#define archive_write_finish(x) \
-	archive_write_free(x)
-
-#define archive_compression_name(x) \
-	archive_filter_name(x, 0)
-
-#endif
-
 #ifndef __arraycount
 #define __arraycount(x) (sizeof(x) / sizeof(*x))
 #endif

--- a/lib/package_unpack.c
+++ b/lib/package_unpack.c
@@ -670,8 +670,8 @@ xbps_unpack_binary_pkg(struct xbps_handle *xhp, xbps_dictionary_t pkg_repod)
 out:
 	if (pkg_fd != -1)
 		close(pkg_fd);
-	if (ar)
-		archive_read_finish(ar);
+	if (ar != NULL)
+		archive_read_free(ar);
 	if (bpkg)
 		free(bpkg);
 

--- a/lib/plist_fetch.c
+++ b/lib/plist_fetch.c
@@ -103,8 +103,8 @@ open_archive_by_url(struct url *url)
 	archive_read_support_format_tar(a);
 
 	if (archive_read_open(a, f, fetch_archive_open, fetch_archive_read,
-	    fetch_archive_close)) {
-		archive_read_finish(a);
+	    fetch_archive_close) != ARCHIVE_OK) {
+		archive_read_free(a);
 		return NULL;
 	}
 
@@ -128,8 +128,9 @@ open_archive(const char *url)
 		archive_read_support_filter_zstd(a);
 		archive_read_support_format_tar(a);
 
-		if (archive_read_open_filename(a, url, 32768)) {
-			archive_read_finish(a);
+		/* XXX: block size? */
+		if (archive_read_open_filename(a, url, 32768) != ARCHIVE_OK) {
+			archive_read_free(a);
 			return NULL;
 		}
 		return a;
@@ -170,7 +171,7 @@ xbps_archive_fetch_file(const char *url, const char *fname)
 		}
 		archive_read_data_skip(a);
 	}
-	archive_read_finish(a);
+	archive_read_free(a);
 
 	return buf;
 }
@@ -212,7 +213,7 @@ xbps_repo_fetch_remote(struct xbps_repo *repo, const char *url)
 		if (i == 2)
 			break;
 	}
-	archive_read_finish(a);
+	archive_read_free(a);
 
 	if (xbps_object_type(repo->idxmeta) == XBPS_TYPE_DICTIONARY)
 		repo->is_signed = true;
@@ -253,7 +254,7 @@ xbps_archive_fetch_file_into_fd(const char *url, const char *fname, int fd)
 		}
 		archive_read_data_skip(a);
 	}
-	archive_read_finish(a);
+	archive_read_free(a);
 
 	return rv;
 }

--- a/lib/repo.c
+++ b/lib/repo.c
@@ -373,7 +373,7 @@ xbps_repo_close(struct xbps_repo *repo)
 		return;
 
 	if (repo->ar != NULL) {
-		archive_read_finish(repo->ar);
+		archive_read_free(repo->ar);
 		repo->ar = NULL;
 	}
 	if (repo->fd != -1) {

--- a/lib/transaction_files.c
+++ b/lib/transaction_files.c
@@ -732,8 +732,8 @@ collect_binpkg_files(struct xbps_handle *xhp, xbps_dictionary_t pkg_repod,
 out:
 	if (pkg_fd != -1)
 		close(pkg_fd);
-	if (ar)
-		archive_read_finish(ar);
+	if (ar != NULL)
+		archive_read_free(ar);
 	free(bpkg);
 	return rv;
 }


### PR DESCRIPTION
The configure script already requires libarchive 3.3.3 and those compat macros were for libarchive below version 3.0.0.