### PR TITLE
Link libxbps from binaries statically

### DIFF
--- a/mk/prog.mk
+++ b/mk/prog.mk
@@ -49,11 +49,12 @@ endif
 $(BIN).static: $(OBJS) $(TOPDIR)/lib/libxbps.a
 	@printf " [CCLD]\t\t$@\n"
 	${SILENT}$(CC) -static $(OBJS) $(CPPFLAGS) -L$(TOPDIR)/lib \
-		$(CFLAGS) $(LDFLAGS) $(PROG_LDFLAGS) $(STATIC_LIBS) -o $@
+		$(CFLAGS) $(LDFLAGS) $(PROG_LDFLAGS) \
+		$(STATIC_LIBS) -o $@
 
-$(BIN): $(OBJS) $(TOPDIR)/lib/libxbps.so
+$(BIN): $(OBJS) $(TOPDIR)/lib/libxbps.a
 	@printf " [CCLD]\t\t$@\n"
 	${SILENT}$(CC) $^ $(CPPFLAGS) -L$(TOPDIR)/lib \
 		$(CFLAGS) $(PROG_CFLAGS) $(LDFLAGS) $(PROG_LDFLAGS) \
-		-lxbps -o $@
+		$(STATIC_LIBS) -o $@
 


### PR DESCRIPTION
Allows to share code between binaries without exposing it to world.

Dynamic libxbps could be removed, as there are no known consumers.
Alternatively static only libxbps-private could be added and shared library could be trimmed to useful part (no xbps_archive_, xbps_mmap_file).