### PR TITLE
Conf files fixes: handle links, don't remove existing files

### DIFF
--- a/bin/xbps-pkgdb/check.c
+++ b/bin/xbps-pkgdb/check.c
@@ -122,9 +122,10 @@ check_pkg_integrity(struct xbps_handle *xhp,
 	}
 
 	{
+		xbps_dictionary_t both[] = {opkgd, filesd};
 		struct check_unit checks[] = {
 			{check_pkg_files, filesd},
-			{check_pkg_symlinks, filesd},
+			{check_pkg_symlinks, both},
 			{check_pkg_rundeps, opkgd},
 			{check_pkg_unneeded, opkgd},
 			{check_pkg_alternatives, opkgd},

--- a/bin/xbps-pkgdb/check_pkg_symlinks.c
+++ b/bin/xbps-pkgdb/check_pkg_symlinks.c
@@ -51,12 +51,16 @@ check_pkg_symlinks(struct xbps_handle *xhp, const char *pkgname, void *arg)
 {
 	xbps_array_t array;
 	xbps_object_t obj;
-	xbps_dictionary_t filesd = arg;
+	xbps_dictionary_t *dicts = arg;
+	xbps_dictionary_t pkgd = dicts[0];
+	xbps_dictionary_t filesd = dicts[1];
+	xbps_array_t conf_files;
 	int rv = 0;
 
 	array = xbps_dictionary_get(filesd, "links");
 	if (array == NULL)
 		return 0;
+	conf_files = xbps_dictionary_get(pkgd, "conf_files");
 
 	for (unsigned int i = 0; i < xbps_array_count(array); i++) {
 		const char *file = NULL, *tgt = NULL;
@@ -86,7 +90,7 @@ check_pkg_symlinks(struct xbps_handle *xhp, const char *pkgname, void *arg)
 			rv = -1;
 			continue;
 		}
-		if (strcmp(lnk, tgt)) {
+		if (strcmp(lnk, tgt) && (!conf_files || !xbps_match_string_in_array(conf_files, lnk))) {
 			xbps_warn_printf("%s: modified symlink %s "
 			    "points to %s (shall be %s)\n",
 			    pkgname, file, lnk, tgt);

--- a/include/xbps_api_impl.h
+++ b/include/xbps_api_impl.h
@@ -80,7 +80,7 @@ int HIDDEN xbps_cb_message(struct xbps_handle *, xbps_dictionary_t, const char *
 int HIDDEN xbps_entry_is_a_conf_file(xbps_dictionary_t, const char *);
 int HIDDEN xbps_entry_install_conf_file(struct xbps_handle *, xbps_dictionary_t,
 		xbps_dictionary_t, struct archive_entry *, const char *,
-		const char *, bool);
+		const char *, struct stat *);
 xbps_dictionary_t HIDDEN xbps_find_virtualpkg_in_conf(struct xbps_handle *,
 		xbps_dictionary_t, const char *);
 xbps_dictionary_t HIDDEN xbps_find_pkg_in_dict(xbps_dictionary_t, const char *);

--- a/lib/package_config_files.c
+++ b/lib/package_config_files.c
@@ -149,15 +149,6 @@ xbps_entry_install_conf_file(struct xbps_handle *xhp,
 	}
 
 	read_conf_file(&orig, entry_pname, pkg_filesd);
-	/*
-	 * First case: original hash not found, install new file.
-	 */
-	if (orig.data == NULL) {
-		xbps_dbg_printf(xhp, "%s: conf_file %s not installed\n",
-		    pkgver, entry_pname);
-		rv = 1;
-		goto out;
-	}
 
 	/*
 	 * Compare original, installed and new hash for current file.
@@ -169,7 +160,7 @@ xbps_entry_install_conf_file(struct xbps_handle *xhp,
 				file = buf;
 			}
 			cur.is_link = true;
-			lnk = xbps_symlink_target(xhp, file, orig.data);
+			lnk = xbps_symlink_target(xhp, file, new.data);
 			cur.data = lnk;
 			if (!cur.data) {
 				/*
@@ -235,6 +226,8 @@ xbps_entry_install_conf_file(struct xbps_handle *xhp,
 			rv = 0;
 		/*
 		 * Orig = X, Curr = Y, New = Y
+		 * or
+		 * Orig not exists, Curr = Y, New = Y
 		 *
 		 * Keep file as is because changes made are compatible
 		 * with new version.
@@ -248,6 +241,8 @@ xbps_entry_install_conf_file(struct xbps_handle *xhp,
 		 * Orig = X, Curr = Y, New = Z
 		 * or
 		 * Orig = X, Curr = X, New = Y if keepconf is set
+		 * or
+		 * Orig not exists, Curr = Y, New = Z
 		 *
 		 * Install new file as <file>.new-<version>
 		 */

--- a/lib/package_config_files.c
+++ b/lib/package_config_files.c
@@ -1,5 +1,6 @@
 /*-
  * Copyright (c) 2009-2014 Juan Romero Pardines.
+ * Copyright (c) 2021 Piotr Wójcik
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,28 +31,66 @@
 
 #include "xbps_api_impl.h"
 
+struct conf_file_contents {
+	bool is_link;
+	const char *data;
+};
+
+static bool
+equal(struct conf_file_contents *a, struct conf_file_contents *b) {
+	return a->is_link == b->is_link && a->data && b->data && strcmp(a->data, b->data) == 0;
+}
+
+static void
+read_conf_file(struct conf_file_contents *conf, const char *entry_pname, xbps_dictionary_t filesd) {
+	xbps_object_iterator_t iter;
+	xbps_object_t obj;
+	const char *cffile;
+	bool ok;
+
+	iter = xbps_array_iter_from_dict(filesd, "conf_files");
+	if (iter) {
+		while ((obj = xbps_object_iterator_next(iter))) {
+			ok = xbps_dictionary_get_cstring_nocopy(obj, "file", &cffile);
+			if (!ok)
+				continue;
+			if (*entry_pname == '.' && strcmp(entry_pname+1, cffile) == 0) {
+				conf->is_link = false;
+				xbps_dictionary_get_cstring_nocopy(obj, "sha256", &conf->data);
+				break;
+			}
+		}
+		xbps_object_iterator_release(iter);
+	}
+	iter = xbps_array_iter_from_dict(filesd, "links");
+	if (iter) {
+		while ((obj = xbps_object_iterator_next(iter))) {
+			ok = xbps_dictionary_get_cstring_nocopy(obj, "file", &cffile);
+			if (!ok)
+				continue;
+			if (*entry_pname == '.' && strcmp(entry_pname+1, cffile) == 0) {
+				conf->is_link = true;
+				xbps_dictionary_get_cstring_nocopy(obj, "target", &conf->data);
+				break;
+			}
+		}
+		xbps_object_iterator_release(iter);
+	}
+}
+
 /*
  * Returns true if entry is a configuration file, false otherwise.
  */
 int HIDDEN
-xbps_entry_is_a_conf_file(xbps_dictionary_t filesd,
+xbps_entry_is_a_conf_file(xbps_dictionary_t propsd,
 			  const char *entry_pname)
 {
 	xbps_array_t array;
-	xbps_dictionary_t d;
-	const char *cffile;
 
-	array = xbps_dictionary_get(filesd, "conf_files");
+	array = xbps_dictionary_get(propsd, "conf_files");
 	if (xbps_array_count(array) == 0)
 		return false;
-
-	for (unsigned int i = 0; i < xbps_array_count(array); i++) {
-		d = xbps_array_get(array, i);
-		xbps_dictionary_get_cstring_nocopy(d, "file", &cffile);
-		if (strcmp(cffile, entry_pname) == 0)
-			return true;
-	}
-	return false;
+	return xbps_match_string_in_array(array, entry_pname);
 }
 
 /*
@@ -64,23 +103,25 @@ xbps_entry_install_conf_file(struct xbps_handle *xhp,
 			     struct archive_entry *entry,
 			     const char *entry_pname,
 			     const char *pkgver,
-			     bool mysymlink)
+			     struct stat *st)
 {
-	xbps_object_t obj, obj2;
-	xbps_object_iterator_t iter, iter2;
-	const char *version = NULL, *cffile, *sha256_new = NULL;
-	char buf[PATH_MAX], sha256_cur[XBPS_SHA256_SIZE];
-	const char *sha256_orig = NULL;
+	const char *version = NULL;
+	char *lnk = NULL;
+	char buf[PATH_MAX], sha256_cur[PATH_MAX];
+	struct conf_file_contents orig = {0}, cur = {0}, new = {0};
 	int rv = 0;
+
 
 	assert(xbps_object_type(binpkg_filesd) == XBPS_TYPE_DICTIONARY);
 	assert(entry);
 	assert(entry_pname);
 	assert(pkgver);
 
-	iter = xbps_array_iter_from_dict(binpkg_filesd, "conf_files");
-	if (iter == NULL)
-		return -1;
+	read_conf_file(&new, entry_pname, binpkg_filesd);
+
+	if (new.data == NULL) {
+		goto out;
+	}
 
 	/*
 	 * Get original hash for the file from current
@@ -89,10 +130,9 @@ xbps_entry_install_conf_file(struct xbps_handle *xhp,
 	xbps_dbg_printf(xhp, "%s: processing conf_file %s\n",
 	    pkgver, entry_pname);
 
-	if (pkg_filesd == NULL || mysymlink) {
+	if (pkg_filesd == NULL) {
 		/*
-		 * 1. File exists on disk but it's not managed by the same package.
-		 * 2. File exists on disk as symlink.
+		 * File exists on disk but it's not managed by the same package.
 		 * Install it as file.new-<version>.
 		 */
 		version = xbps_pkg_version(pkgver);
@@ -108,23 +148,11 @@ xbps_entry_install_conf_file(struct xbps_handle *xhp,
 		goto out;
 	}
 
-	iter2 = xbps_array_iter_from_dict(pkg_filesd, "conf_files");
-	if (iter2 != NULL) {
-		while ((obj2 = xbps_object_iterator_next(iter2))) {
-			xbps_dictionary_get_cstring_nocopy(obj2,
-			    "file", &cffile);
-			snprintf(buf, sizeof(buf), ".%s", cffile);
-			if (strcmp(entry_pname, buf) == 0) {
-				xbps_dictionary_get_cstring_nocopy(obj2, "sha256", &sha256_orig);
-				break;
-			}
-		}
-		xbps_object_iterator_release(iter2);
-	}
+	read_conf_file(&orig, entry_pname, pkg_filesd);
 	/*
 	 * First case: original hash not found, install new file.
 	 */
-	if (sha256_orig == NULL) {
+	if (orig.data == NULL) {
 		xbps_dbg_printf(xhp, "%s: conf_file %s not installed\n",
 		    pkgver, entry_pname);
 		rv = 1;
@@ -134,13 +162,23 @@ xbps_entry_install_conf_file(struct xbps_handle *xhp,
 	/*
 	 * Compare original, installed and new hash for current file.
 	 */
-	while ((obj = xbps_object_iterator_next(iter))) {
-		xbps_dictionary_get_cstring_nocopy(obj, "file", &cffile);
-		snprintf(buf, sizeof(buf), ".%s", cffile);
-		if (strcmp(entry_pname, buf)) {
-			continue;
-		}
-		if (!xbps_file_sha256(sha256_cur, sizeof sha256_cur, buf)) {
+		if (S_ISLNK(st->st_mode)) {
+			const char *file = entry_pname + 1;
+			if (strcmp(xhp->rootdir, "/") != 0) {
+				snprintf(buf, sizeof(buf), "%s%s", xhp->rootdir, file);
+				file = buf;
+			}
+			cur.is_link = true;
+			lnk = xbps_symlink_target(xhp, file, orig.data);
+			cur.data = lnk;
+			if (!cur.data) {
+				/*
+				 * File not installed, install new one.
+				 */
+				rv = 1;
+				goto out;
+			}
+		} else if (!xbps_file_sha256(sha256_cur, sizeof sha256_cur, entry_pname)) {
 			if (errno == ENOENT) {
 				/*
 				 * File not installed, install new one.
@@ -148,41 +186,39 @@ xbps_entry_install_conf_file(struct xbps_handle *xhp,
 				xbps_dbg_printf(xhp, "%s: conf_file %s not "
 				    "installed\n", pkgver, entry_pname);
 				rv = 1;
-				break;
 			} else {
 				rv = -1;
-				break;
 			}
+			goto out;
+		} else {
+			cur.is_link = false;
+			cur.data = sha256_cur;
 		}
-		xbps_dictionary_get_cstring_nocopy(obj, "sha256", &sha256_new);
+
 		/*
 		 * Orig = X, Curr = X, New = X
 		 *
 		 * Keep file as is (no changes).
 		 */
-		if ((strcmp(sha256_orig, sha256_cur) == 0) &&
-		    (strcmp(sha256_orig, sha256_new) == 0) &&
-		    (strcmp(sha256_cur, sha256_new) == 0)) {
+		if (equal(&orig, &cur) &&
+		    equal(&cur, &new)) {
 			xbps_dbg_printf(xhp, "%s: conf_file %s orig = X, "
 			    "cur = X, new = X\n", pkgver, entry_pname);
 			rv = 0;
-			break;
 		/*
 		 * Orig = X, Curr = X, New = Y
 		 *
 		 * Install new file (installed file hasn't been modified) if
 		 * configuration option keepconfig is NOT set.
 		 */
-		} else if ((strcmp(sha256_orig, sha256_cur) == 0) &&
-			   (strcmp(sha256_orig, sha256_new)) &&
-			   (strcmp(sha256_cur, sha256_new)) &&
+		} else if (equal(&orig, &cur) &&
+			   !equal(&cur, &new) &&
 			   (!(xhp->flags & XBPS_FLAG_KEEP_CONFIG))) {
 			xbps_set_cb_state(xhp, XBPS_STATE_CONFIG_FILE,
 			    0, pkgver,
 			    "Updating configuration file `%s' provided "
-			    "by `%s'.", cffile, pkgver);
+			    "by `%s'.", entry_pname, pkgver);
 			rv = 1;
-			break;
 		/*
 		 * Orig = X, Curr = Y, New = X
 		 *
@@ -190,28 +226,24 @@ xbps_entry_install_conf_file(struct xbps_handle *xhp,
 		 * but new package doesn't contain new changes compared
 		 * to the original version.
 		 */
-		} else if ((strcmp(sha256_orig, sha256_new) == 0) &&
-			   (strcmp(sha256_cur, sha256_new)) &&
-			   (strcmp(sha256_orig, sha256_cur))) {
+		} else if (equal(&orig, &new) &&
+			   !equal(&orig, &cur)) {
 			xbps_set_cb_state(xhp, XBPS_STATE_CONFIG_FILE,
 			    0, pkgver,
 			    "Keeping modified configuration file `%s'.",
-			    cffile);
+			    entry_pname);
 			rv = 0;
-			break;
 		/*
 		 * Orig = X, Curr = Y, New = Y
 		 *
 		 * Keep file as is because changes made are compatible
 		 * with new version.
 		 */
-		} else if ((strcmp(sha256_cur, sha256_new) == 0) &&
-			   (strcmp(sha256_orig, sha256_new)) &&
-			   (strcmp(sha256_orig, sha256_cur))) {
+		} else if (equal(&cur, &new) &&
+			   !equal(&orig, &cur)) {
 			xbps_dbg_printf(xhp, "%s: conf_file %s orig = X, "
 			    "cur = Y, new = Y\n", pkgver, entry_pname);
 			rv = 0;
-			break;
 		/*
 		 * Orig = X, Curr = Y, New = Z
 		 * or
@@ -219,24 +251,18 @@ xbps_entry_install_conf_file(struct xbps_handle *xhp,
 		 *
 		 * Install new file as <file>.new-<version>
 		 */
-		} else if (((strcmp(sha256_orig, sha256_cur)) &&
-			    (strcmp(sha256_cur, sha256_new)) &&
-			    (strcmp(sha256_orig, sha256_new))) ||
-			    (xhp->flags & XBPS_FLAG_KEEP_CONFIG)) {
+		} else {
 			version = xbps_pkg_version(pkgver);
 			assert(version);
-			snprintf(buf, sizeof(buf), ".%s.new-%s", cffile, version);
+			snprintf(buf, sizeof(buf), "%s.new-%s", entry_pname, version);
 			xbps_set_cb_state(xhp, XBPS_STATE_CONFIG_FILE,
-			    0, pkgver, "File `%s' exists, installing configuration file to `%s'.", cffile, buf);
+			    0, pkgver, "File `%s' exists, installing configuration file to `%s'.", entry_pname, buf);
 			archive_entry_copy_pathname(entry, buf);
 			rv = 1;
-			break;
 		}
-	}
 
 out:
-
-	xbps_object_iterator_release(iter);
+	free(lnk);
 
 	xbps_dbg_printf(xhp, "%s: conf_file %s returned %d\n",
 	    pkgver, entry_pname, rv);

--- a/tests/xbps/libxbps/shell/conf_files_test.sh
+++ b/tests/xbps/libxbps/shell/conf_files_test.sh
@@ -456,6 +456,382 @@ tc10_body() {
 	atf_check_equal $? 0
 }
 
+# 1st link test: modified configuration link on disk, unmodified on upgrade.
+#	result: keep link as is on disk.
+atf_test_case tcl1
+
+tcl1_head() {
+	atf_set "descr" "Tests for configuration link handling: on-disk modified, upgrade unmodified"
+}
+
+tcl1_body() {
+	mkdir repo
+	cd repo
+	mkdir pkg_a
+	ln -s original pkg_a/cf1.conf
+	xbps-create -A noarch -n a-0.1_1 -s "pkg a" --config-files "/cf1.conf" pkg_a
+	atf_check_equal $? 0
+	rm -rf pkg_a
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	xbps-install -C null.conf -r rootdir --repository=$PWD -yvd a
+	atf_check_equal $? 0
+
+	ln -sf custom rootdir/cf1.conf
+	mkdir pkg_a
+	ln -s original pkg_a/cf1.conf
+	xbps-create -A noarch -n a-0.2_1 -s "pkg a" --config-files "/cf1.conf" pkg_a
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	rm -rf pkg_a
+	atf_check_equal $? 0
+	xbps-install -C null.conf -r rootdir --repository=$PWD -yuvd
+	atf_check_equal $? 0
+	atf_check_equal "$(readlink rootdir/cf1.conf)" custom
+}
+
+# 2nd test: modified configuration link on disk, modified on upgrade.
+#	result: install new link as "<conf_file>.new-<version>".
+atf_test_case tcl2
+
+tcl2_head() {
+	atf_set "descr" "Tests for configuration link handling: on-disk modified, upgrade modified"
+}
+
+tcl2_body() {
+	mkdir repo
+	cd repo
+	mkdir pkg_a
+	ln -s original pkg_a/cf1.conf
+	xbps-create -A noarch -n a-0.1_1 -s "pkg a" --config-files "/cf1.conf" pkg_a
+	atf_check_equal $? 0
+	rm -rf pkg_a
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	xbps-install -C null.conf -r rootdir --repository=$PWD -yvd a
+	atf_check_equal $? 0
+
+	ln -sf custom rootdir/cf1.conf
+	mkdir pkg_a
+	ln -s updated pkg_a/cf1.conf
+	xbps-create -A noarch -n a-0.2_1 -s "pkg a" --config-files "/cf1.conf" pkg_a
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	rm -rf pkg_a
+	atf_check_equal $? 0
+	xbps-install -C null.conf -r rootdir --repository=$PWD -yuvd
+	atf_check_equal $? 0
+	atf_check_equal "$(readlink rootdir/cf1.conf)" custom
+	test -h rootdir/cf1.conf.new-0.2_1
+	atf_check_equal $? 0
+}
+
+# 3rd test: modified configuration link on disk, unmodified on upgrade.
+#	result: keep link on disk as is.
+atf_test_case tcl3
+
+tcl3_head() {
+	atf_set "descr" "Tests for configuration link handling: on-disk modified, upgrade unmodified"
+}
+
+tcl3_body() {
+	mkdir repo
+	cd repo
+	mkdir pkg_a
+	ln -s original pkg_a/cf1.conf
+	xbps-create -A noarch -n a-0.1_1 -s "pkg a" --config-files "/cf1.conf" pkg_a
+	atf_check_equal $? 0
+	rm -rf pkg_a
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	xbps-install -C null.conf -r rootdir --repository=$PWD -yvd a
+	atf_check_equal $? 0
+
+	ln -sf custom rootdir/cf1.conf
+	mkdir pkg_a
+	ln -s original pkg_a/cf1.conf
+	xbps-create -A noarch -n a-0.2_1 -s "pkg a" --config-files "/cf1.conf" pkg_a
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	rm -rf pkg_a
+	atf_check_equal $? 0
+	xbps-install -C null.conf -r rootdir --repository=$PWD -yuvd
+	atf_check_equal $? 0
+	atf_check_equal "$(readlink rootdir/cf1.conf)" custom
+}
+
+# 4th test: existent link on disk; new package defines configuration link.
+#	result: keep on-disk link as is, install new conf link as file.new-<version>.
+atf_test_case tcl4
+
+tcl4_head() {
+	atf_set "descr" "Tests for configuration link handling: existent on-disk, new install"
+}
+
+tcl4_body() {
+	mkdir repo
+	cd repo
+	mkdir -p pkg_a/etc
+	ln -s original pkg_a/etc/cf1.conf
+	xbps-create -A noarch -n a-0.1_1 -s "pkg a" --config-files "/etc/cf1.conf" pkg_a
+	atf_check_equal $? 0
+	rm -rf pkg_a
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	mkdir -p rootdir/etc
+	ln -s custom rootdir/etc/cf1.conf
+	xbps-install -C null.conf -r rootdir --repository=$PWD -yvd a
+	atf_check_equal $? 0
+	atf_check_equal "$(readlink rootdir/etc/cf1.conf)" custom
+	atf_check_equal "$(readlink rootdir/etc/cf1.conf.new-0.1_1)" original
+}
+
+# 5th test: configuration link replaced with regular file on disk, modified on upgrade.
+#	result: install new link as "<conf_file>.new-<version>".
+atf_test_case tcl5
+
+tcl5_head() {
+	atf_set "descr" "Tests for configuration link handling: on-disk replaced with symlink, upgrade modified"
+}
+
+tcl5_body() {
+	mkdir repo
+	cd repo
+	mkdir pkg_a
+	ln -s original pkg_a/cf1.conf
+	xbps-create -A noarch -n a-0.1_1 -s "pkg a" --config-files "/cf1.conf" pkg_a
+	atf_check_equal $?a 0a
+	rm -rf pkg_a
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $?b 0b
+	xbps-install -C null.conf -r rootdir --repository=$PWD -yvd a
+	atf_check_equal $?c 0c
+
+	rm rootdir/cf1.conf
+	echo 'key=value' > rootdir/cf1.conf
+
+	mkdir pkg_a
+	ln -s updated pkg_a/cf1.conf
+	xbps-create -A noarch -n a-0.2_1 -s "pkg a" --config-files "/cf1.conf" pkg_a
+	atf_check_equal $?d 0d
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $?e 0e
+	rm -rf pkg_a
+
+	xbps-install -C null.conf -r rootdir --repository=$PWD -yuvd
+	atf_check_equal $?f 0f
+
+	atf_check_equal "$(cat rootdir/cf1.conf)" "key=value"
+	test -f rootdir/cf1.conf
+	atf_check_equal $?g 0g
+	test -h rootdir/cf1.conf.new-0.2_1
+	atf_check_equal $?h 0h
+}
+
+# 6th test: unmodified configuration link on disk, keepconf=true, modified on upgrade.
+#	result: install new link as "<conf_file>.new-<version>".
+atf_test_case tcl6
+
+tcl6_head() {
+	atf_set "descr" "Tests for configuration link handling: on-disk unmodified, keepconf=true, upgrade modified"
+}
+
+tcl6_body() {
+	mkdir repo
+	cd repo
+	mkdir pkg_a
+	ln -s original pkg_a/cf1.conf
+	xbps-create -A noarch -n a-0.1_1 -s "pkg a" --config-files "/cf1.conf" pkg_a
+	atf_check_equal $? 0
+	rm -rf pkg_a
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+
+	mkdir -p rootdir/xbps.d
+	echo "keepconf=true" > rootdir/xbps.d/keepconf.conf
+
+	xbps-install -C xbps.d -r rootdir --repository=$PWD/repo -yvd a
+	atf_check_equal $? 0
+
+	cd repo
+	mkdir pkg_a
+	ln -s updated pkg_a/cf1.conf
+	xbps-create -A noarch -n a-0.2_1 -s "pkg a" --config-files "/cf1.conf" pkg_a
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	rm -rf pkg_a
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -C xbps.d -r rootdir --repository=$PWD/repo -yuvd
+	atf_check_equal $? 0
+	atf_check_equal "$(readlink rootdir/cf1.conf)" original
+	atf_check_equal "$(readlink rootdir/cf1.conf.new-0.2_1)" updated
+}
+
+# 7th test: unmodified configuration link on disk, modified on upgrade.
+#	result: update link
+atf_test_case tcl7
+
+tcl7_head() {
+	atf_set "descr" "Tests for configuration link handling: on-disk unmodified, upgrade modified"
+}
+
+tcl7_body() {
+	mkdir repo
+	cd repo
+	mkdir pkg_a
+	ln -s original pkg_a/cf1.conf
+	xbps-create -A noarch -n a-0.1_1 -s "pkg a" --config-files "/cf1.conf" pkg_a
+	atf_check_equal $? 0
+	rm -rf pkg_a
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -C xbps.d -r rootdir --repository=$PWD/repo -yvd a
+	atf_check_equal $? 0
+
+	cd repo
+	mkdir pkg_a
+	ln -s updated pkg_a/cf1.conf
+	xbps-create -A noarch -n a-0.2_1 -s "pkg a" --config-files "/cf1.conf" pkg_a
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	rm -rf pkg_a
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -C xbps.d -r rootdir --repository=$PWD/repo -yuvd
+	atf_check_equal $? 0
+	atf_check_equal "$(readlink rootdir/cf1.conf)" updated
+}
+
+# 8th test: modified configuration link on disk to same as updated, modified on upgrade.
+#	result: keep on-disk link as is, don't install new conf link as file.new-<version>.
+atf_test_case tcl8
+
+tcl8_head() {
+	atf_set "descr" "Tests for configuration link handling: on-disk modified, matches upgrade"
+}
+
+tcl8_body() {
+	mkdir repo
+	cd repo
+	mkdir pkg_a
+	ln -s original pkg_a/cf1.conf
+	xbps-create -A noarch -n a-0.1_1 -s "pkg a" --config-files "/cf1.conf" pkg_a
+	atf_check_equal $? 0
+	rm -rf pkg_a
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -C xbps.d -r rootdir --repository=$PWD/repo -yvd a
+	atf_check_equal $? 0
+	ln -sf improved rootdir/cf1.conf
+
+	cd repo
+	mkdir pkg_a
+	ln -s improved pkg_a/cf1.conf
+	xbps-create -A noarch -n a-0.2_1 -s "pkg a" --config-files "/cf1.conf" pkg_a
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	rm -rf pkg_a
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -C xbps.d -r rootdir --repository=$PWD/repo -yuvd
+	atf_check_equal $? 0
+	atf_check_equal "$(readlink rootdir/cf1.conf)" improved
+	test '!' -e rootdir/cf1.conf.new-0.2_1
+	atf_check_equal $? 0
+}
+
+# 9th test: removed configuration link on disk, unmodified on upgrade.
+#	result: install link, don't install new conf link as file.new-<version>.
+atf_test_case tcl9
+
+tcl9_head() {
+	atf_set "descr" "Tests for configuration link handling: on-disk removed, upgrade unmodified"
+}
+
+tcl9_body() {
+	mkdir repo
+	cd repo
+	mkdir pkg_a
+	ln -s original pkg_a/cf1.conf
+	xbps-create -A noarch -n a-0.1_1 -s "pkg a" --config-files "/cf1.conf" pkg_a
+	atf_check_equal $? 0
+	rm -rf pkg_a
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -C xbps.d -r rootdir --repository=$PWD/repo -yvd a
+	atf_check_equal $? 0
+	rm rootdir/cf1.conf
+
+	cd repo
+	mkdir pkg_a
+	ln -s original pkg_a/cf1.conf
+	xbps-create -A noarch -n a-0.2_1 -s "pkg a" --config-files "/cf1.conf" pkg_a
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	rm -rf pkg_a
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -C xbps.d -r rootdir --repository=$PWD/repo -yuvd
+	atf_check_equal $? 0
+	atf_check_equal "$(readlink rootdir/cf1.conf)" original
+	test '!' -e rootdir/cf1.conf.new-0.2_1
+	atf_check_equal $? 0
+}
+
+
+# 10th test: removed configuration link on disk, modified on upgrade.
+#	result: install link, don't install new conf link as file.new-<version>.
+atf_test_case tcl10
+
+tcl10_head() {
+	atf_set "descr" "Tests for configuration link handling: on-disk removed, upgrade modified"
+}
+
+tcl10_body() {
+	mkdir repo
+	cd repo
+	mkdir pkg_a
+	ln -s original pkg_a/cf1.conf
+	xbps-create -A noarch -n a-0.1_1 -s "pkg a" --config-files "/cf1.conf" pkg_a
+	atf_check_equal $? 0
+	rm -rf pkg_a
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -C xbps.d -r rootdir --repository=$PWD/repo -yvd a
+	atf_check_equal $? 0
+	rm rootdir/cf1.conf
+
+	cd repo
+	mkdir pkg_a
+	ln -s updated pkg_a/cf1.conf
+	xbps-create -A noarch -n a-0.2_1 -s "pkg a" --config-files "/cf1.conf" pkg_a
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	rm -rf pkg_a
+	atf_check_equal $? 0
+	cd ..
+
+	xbps-install -C xbps.d -r rootdir --repository=$PWD/repo -yuvd
+	atf_check_equal $? 0
+	atf_check_equal "$(readlink rootdir/cf1.conf)" updated
+	test '!' -e rootdir/cf1.conf.new-0.2_1
+	atf_check_equal $? 0
+}
+
 atf_init_test_cases() {
 	atf_add_test_case tc1
 	atf_add_test_case tc2
@@ -467,4 +843,15 @@ atf_init_test_cases() {
 	atf_add_test_case tc8
 	atf_add_test_case tc9
 	atf_add_test_case tc10
+
+	atf_add_test_case tcl1
+	atf_add_test_case tcl2
+	atf_add_test_case tcl3
+	atf_add_test_case tcl4
+	atf_add_test_case tcl5
+	atf_add_test_case tcl6
+	atf_add_test_case tcl7
+	atf_add_test_case tcl8
+	atf_add_test_case tcl9
+	atf_add_test_case tcl10
 }


### PR DESCRIPTION
Last commit fixes #342.
Other allows to change target of symlink if it is marked as conf_file.