### PR TITLE
xbps-query: list unavailable repositories in -L mode

### DIFF
--- a/include/xbps.h.in
+++ b/include/xbps.h.in
@@ -1475,6 +1475,8 @@ int xbps_rpool_sync(struct xbps_handle *xhp, const char *uri);
  * argument can be used in the callbacks to stop immediately the loop if
  * set to true, otherwise it will only be stopped if it returns a
  * non-zero value.
+ * Removes repos failed to open from pool. This condition causes function
+ * to return error, but don't break the loop.
  *
  * @param[in] xhp Pointer to the xbps_handle struct.
  * @param[in] fn Function callback to execute for every repository registered in

--- a/tests/xbps/xbps-query/Kyuafile
+++ b/tests/xbps/xbps-query/Kyuafile
@@ -2,4 +2,5 @@ syntax("kyuafile", 1)
 
 test_suite("xbps-query")
 atf_test_program{name="ignore_repos_test"}
+atf_test_program{name="list_test"}
 atf_test_program{name="remote_test"}

--- a/tests/xbps/xbps-query/Makefile
+++ b/tests/xbps/xbps-query/Makefile
@@ -1,7 +1,7 @@
 TOPDIR = ../../..
 -include $(TOPDIR)/config.mk
 
-TESTSHELL = ignore_repos_test remote_test
+TESTSHELL = ignore_repos_test list_test remote_test
 TESTSSUBDIR = xbps/xbps-query
 EXTRA_FILES = Kyuafile
 

--- a/tests/xbps/xbps-query/list_test.sh
+++ b/tests/xbps/xbps-query/list_test.sh
@@ -1,0 +1,28 @@
+#! /usr/bin/env atf-sh
+# Test that xbps-query(1) list modes work as expected
+
+atf_test_case list_repos
+
+list_repos_head() {
+	atf_set "descr" "xbps-query(1) -L"
+}
+
+list_repos_body() {
+	mkdir -p some_repo pkg_A/bin
+	touch pkg_A/bin/file
+	cd some_repo
+	xbps-create -A noarch -n foo-1.0_1 -s "foo pkg" ../pkg_A
+	atf_check_equal $? 0
+	xbps-create -A noarch -n baz-1.0_1 -s "baz pkg" ../pkg_A
+	atf_check_equal $? 0
+	xbps-rindex -d -a $PWD/*.xbps
+	atf_check_equal $? 0
+	rm -f *.xbps
+	cd ..
+	output="$(xbps-query -C empty.conf -i --repository=some_repo --repository=vanished_repo -L | tr -d '\n')"
+	atf_check_equal "$output" "    2 ${PWD}/some_repo (RSA unsigned)	-1 vanished_repo (RSA maybe-signed)"
+}
+
+atf_init_test_cases() {
+	atf_add_test_case list_repos
+}


### PR DESCRIPTION
xbps-query: list unavailable repositories in -L mode

As documented in manpage. Example is when current user have no permissions to read local repo.