### PR TITLE
xbps-install: continue to list all remaining packages not found repositories after failing to find a package

### DIFF
--- a/bin/xbps-install/main.c
+++ b/bin/xbps-install/main.c
@@ -274,18 +274,21 @@ main(int argc, char **argv)
 		rv = exec_transaction(&xh, maxcols, yes, drun);
 	} else if (!update) {
 		/* Install target packages */
+		bool target_pkgs_not_found = false;
 		for (i = optind; i < argc; i++) {
 			rv = install_new_pkg(&xh, argv[i], force);
 			if (rv == EEXIST) {
 				/* pkg already installed, ignore */
 				rv = 0;
 				eexist++;
+			} else if (rv == ENOENT) {
+				target_pkgs_not_found = true;
 			} else if (rv != 0) {
 				xbps_end(&xh);
 				exit(rv);
 			}
 		}
-		if (eexist == argc)
+		if (eexist == argc || target_pkgs_not_found)
 			goto out;
 
 		rv = exec_transaction(&xh, maxcols, yes, drun);

--- a/bin/xbps-install/main.c
+++ b/bin/xbps-install/main.c
@@ -257,18 +257,21 @@ main(int argc, char **argv)
 		rv = dist_upgrade(&xh, maxcols, yes, drun);
 	} else if (update) {
 		/* Update target packages */
+        bool target_pkgs_not_found = false;
 		for (i = optind; i < argc; i++) {
 			rv = update_pkg(&xh, argv[i], force);
 			if (rv == EEXIST) {
 				/* pkg already updated, ignore */
 				rv = 0;
 				eexist++;
+            } else if (rv == ENOENT) {
+                target_pkgs_not_found = true;
 			} else if (rv != 0) {
 				xbps_end(&xh);
 				exit(rv);
 			}
 		}
-		if (eexist == argc)
+		if (eexist == argc || target_pkgs_not_found)
 			goto out;
 
 		rv = exec_transaction(&xh, maxcols, yes, drun);

--- a/bin/xbps-install/main.c
+++ b/bin/xbps-install/main.c
@@ -257,15 +257,15 @@ main(int argc, char **argv)
 		rv = dist_upgrade(&xh, maxcols, yes, drun);
 	} else if (update) {
 		/* Update target packages */
-        bool target_pkgs_not_found = false;
+		bool target_pkgs_not_found = false;
 		for (i = optind; i < argc; i++) {
 			rv = update_pkg(&xh, argv[i], force);
 			if (rv == EEXIST) {
 				/* pkg already updated, ignore */
 				rv = 0;
 				eexist++;
-            } else if (rv == ENOENT) {
-                target_pkgs_not_found = true;
+			} else if (rv == ENOENT) {
+				target_pkgs_not_found = true;
 			} else if (rv != 0) {
 				xbps_end(&xh);
 				exit(rv);


### PR DESCRIPTION
Closes issue #432
`xbps-install` will still abort if it cannot find the packages, however it will continue to list the packages it cannot find and those that are already installed. It still remains silent if it can find a package (in the example below, `rust` is found, and is not currently installed.)
```
# xbps-install zlib foo bar grep nonexistent baz rust
Package `zlib' already installed.
Package 'foo' not found in repository pool.
Package 'bar' not found in repository pool.
Package `grep' already installed.
Package 'nonexistent' not found in repository pool.
Package 'baz' not found in repository pool.
```

```
$ make check
===> Summary
Results read from /home/wren/dev/void-linux/xbps/result.db
Test cases: 266 total, 0 skipped, 3 expected failures, 0 broken, 0 failed
```