### PR TITLE
docs: Improve description of keepconf option

### DIFF
--- a/data/xbps.conf
+++ b/data/xbps.conf
@@ -71,19 +71,20 @@
 #	preserve=/etc/file
 #	preserve=/etc/dir/*.conf
 
-## PRESERVING CONFIGURATION
+## PRESERVING UNCHANGED CONFIGURATION FILES
 #
 # The `keepconf` (disabled by default) keyword can be used to prevent
-# xbps from overwriting configuration files.
+# xbps from overwriting unchanged configuration files. Changed configuration
+# files are unaffected by this keyword and are preserved by default.
 #
-# If set to false, xbps will overwrite configuration files if they
-# have not been changed since installation and a newer version is
-# available.
+# If set to false, xbps will overwrite configuration files that have not been
+# changed since installation with their new version (if available).
 #
-# If set to true, xbps will save the new configuration file as
-# <name>.new-<version> if the original configuration file has not been
-# changed since installation.
-# keepconf=true
+# If set to true, xbps will not overwrite configuration files that have not
+# been changed since installation. Instead, the new version (if available) is
+# saved next to the configuration file as <name>.new-<version>.
+#
+#keepconf=true
 
 ## VIRTUAL PACKAGES
 #

--- a/data/xbps.d.5
+++ b/data/xbps.d.5
@@ -96,13 +96,12 @@ Absolute path to a file and file globbing are supported, example:
 .It Sy preserve=/etc/foo/*.conf
 .El
 .It Sy keepconf=true|false
-If set to false (default), xbps will overwrite configuration files if
-they have not been changed since installation and a newer version is
-available.
+If set to false (default), xbps will overwrite configuration files that have
+not been changed since installation with their new version (if available).
 .Pp
-If set to true, xbps will save the new configuration file as
-<name>.new-<version> if the original configuration file has not been
-changed since installation.
+If set to true, xbps will not overwrite configuration files that have not
+been changed since installation. Instead, the new version (if available) is
+saved next to the configuration file as <name>.new-<version>.
 .Pp
 .It Sy repository=url
 Declares a package repository. The


### PR DESCRIPTION
keepconf is a boring option and is not needed in most situations. Make
this more clear in the documentation, e.g. that it only affects
*unchanged* configuration files, and that changed configuration files
are unaffected by this option.