### PR TITLE
xbps-reconfigure: add ability to reconfigure dependencies

### DIFF
--- a/bin/xbps-reconfigure/Makefile
+++ b/bin/xbps-reconfigure/Makefile
@@ -2,5 +2,6 @@ TOPDIR = ../..
 -include $(TOPDIR)/config.mk
 
 BIN =	xbps-reconfigure
+OBJS =	main.o find-deps.o
 
 include $(TOPDIR)/mk/prog.mk

--- a/bin/xbps-reconfigure/defs.h
+++ b/bin/xbps-reconfigure/defs.h
@@ -1,0 +1,34 @@
+/*-
+ * Copyright (c) 2022 classabbyamp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _XBPS_RECONFIGURE_DEFS_H_
+#define _XBPS_RECONFIGURE_DEFS_H_
+
+#include <xbps.h>
+
+/* from find-deps.c */
+int	find_pkg_deps(struct xbps_handle *, const char *, bool, xbps_array_t *);
+
+#endif /* !_XBPS_RECONFIGURE_DEFS_H_ */

--- a/bin/xbps-reconfigure/find-deps.c
+++ b/bin/xbps-reconfigure/find-deps.c
@@ -1,0 +1,49 @@
+/*-
+ * Copyright (c) 2022 classabbyamp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+
+#include <xbps.h>
+#include "defs.h"
+
+int
+find_pkg_deps(struct xbps_handle *xhp, const char *pkgname, bool full, xbps_array_t *rdeps)
+{
+	xbps_dictionary_t pkgd;
+
+	if ((pkgd = xbps_pkgdb_get_pkg(xhp, pkgname)) == NULL) {
+		return errno;
+	}
+
+	if (full) {
+		*rdeps = xbps_pkgdb_get_pkg_fulldeptree(xhp, pkgname);
+
+		if (*rdeps == NULL)
+			return errno;
+	} else {
+		*rdeps = xbps_dictionary_get(pkgd, "run_depends");
+	}
+	return 0;
+}

--- a/bin/xbps-reconfigure/xbps-reconfigure.1
+++ b/bin/xbps-reconfigure/xbps-reconfigure.1
@@ -56,6 +56,16 @@ argument can be a package name or a package name with version.
 This option can be specified multiple times.
 .It Fl r, Fl -rootdir Ar dir
 Specifies a path for the target root directory.
+.It Fl x, Fl -deps
+Configure 
+.Ar PKGNAME...
+and its direct dependencies.
+.It Fl -fulldeptree
+Configure the full dependency tree of
+.Ar PKGNAME...
+when used with
+.Fl x, Fl -deps .
+.
 .It Fl v, Fl -verbose
 Enables verbose messages.
 .It Fl V, Fl -version


### PR DESCRIPTION
adds `-x/--deps` and `--fulldeptree`, that behave similar to the xbps-query modes

fixes #464

### Sample Output
```
$ doas bin/xbps-reconfigure/xbps-reconfigure -fx linux  
linux5.15: configuring ...
Executing post-install kernel hook: 20-dracut ...
dracut: dracut module 'cifs' depends on 'network', which can't be installed
Mode:           real
Files:          2593
Linked:         221 files
Compared:       0 xattrs
Compared:       3866 files
Saved:          17.58 MiB
Duration:       0.030899 seconds
Executing post-install kernel hook: 50-efibootmgr ...
Executing post-install kernel hook: 50-grub ...
Generating grub configuration file ...
Found background: /usr/share/void-artwork/splash.png
Found linux image: /boot/vmlinuz-5.15.34_1
Found initrd image: /boot/initramfs-5.15.34_1.img
Found linux image: /boot/vmlinuz-5.15.32_1
Found initrd image: /boot/initramfs-5.15.32_1.img
Found linux image: /boot/vmlinuz-5.15.30_1
Found initrd image: /boot/initramfs-5.15.30_1.img
Warning: os-prober will be executed to detect other bootable partitions.
Its output will be used to detect bootable binaries on them and create new boot entries.
Found Windows Boot Manager on /dev/nvme0n1p1@/EFI/Microsoft/Boot/bootmgfw.efi
Adding boot menu entry for UEFI Firmware Settings ...
done
linux5.15: configured successfully.
linux-base: configuring ...
linux-base: configured successfully.
linux: configuring ...
linux: configured successfully.
```