### PR TITLE
libxbps: skip creation of symlink with noextract

### DIFF
--- a/lib/package_alternatives.c
+++ b/lib/package_alternatives.c
@@ -168,6 +168,13 @@ create_symlinks(struct xbps_handle *xhp, xbps_array_t a, const char *grname)
 			return -1;
 		}
 
+		/* Skip files that match noextract patterns from configuration file. */
+		if (xhp->noextract && xbps_patterns_match(xhp->noextract, tok1)) {
+			xbps_dbg_printf(xhp, "[alternative] %s skipped (matched by a pattern)\n", tok1);
+			free(alternative);
+			continue;
+		}
+
 		target = strdup(tok2);
 		dir = dirname(tok2);
 


### PR DESCRIPTION
https://github.com/void-linux/void-packages/pull/39284 "broke" my setup. I am using dracut-uefi, so I don't need the `/etc/kernel.d/*/20-initramfs` link. This PR had the possibility to skip the symlink creation (using the noextract).