### PR TITLE
bin/xbps-rindex/remove-obsoletes.c: always `opendir()` pwd

### DIFF
--- a/bin/xbps-rindex/remove-obsoletes.c
+++ b/bin/xbps-rindex/remove-obsoletes.c
@@ -134,7 +134,7 @@ remove_obsoletes(struct xbps_handle *xhp, const char *repodir)
 		rv = errno;
 		goto out;
 	}
-	if ((dirp = opendir(repodir)) == NULL) {
+	if ((dirp = opendir(".")) == NULL) {
 		fprintf(stderr, "xbps-rindex: failed to open %s: %s\n",
 		    repodir, strerror(errno));
 		rv = errno;


### PR DESCRIPTION
If `repodir` is given as a relative path, it will not work because it will try to open the dir relative to itself because it already `chdir()`ed into `repodir`. This fixes `xbps-rindex -r` when relative paths are specified.

fixes #519
