### PR TITLE
lib/repo.c: add user-facing error message when repodata doesn't exist

### DIFF
--- a/lib/repo.c
+++ b/lib/repo.c
@@ -248,6 +248,7 @@ repo_open_with_type(struct xbps_handle *xhp, const char *url, const char *name)
 		int rv = errno;
 		xbps_dbg_printf(xhp, "[repo] `%s' open %s %s\n",
 		    repofile, name, strerror(rv));
+		xbps_error_printf("%s: %s\n", strerror(rv), repofile);
 		goto out;
 	}
 	if (repo_open_local(repo, repofile)) {


### PR DESCRIPTION
Instead of just cryptically exiting 0 when opening a non-existant repodata or stagedata, with the only message existing in the debug output, show an error to the user on stderr.

mentioned in #519
