### PR TITLE
CI: migrate from LGTM to Github CodeQL

### DIFF
--- a/.github/codeql/codeql-config.yaml
+++ b/.github/codeql/codeql-config.yaml
@@ -1,0 +1,5 @@
+queries:
+  - uses: security-extended
+  - uses: security-and-quality
+paths-ignore:
+  - tests/**

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,15 @@
 name: Tests
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - 'master'
+      - 'ci-**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
    testsuite:
       strategy:
@@ -23,7 +33,8 @@ jobs:
       container: ${{ matrix.void_image }}
       steps:
          - uses: actions/checkout@v1
-         - run: |
+         - name: Prepare container
+           run: |
             xbps-install -Syu || xbps-install -yu xbps
             xbps-install -Sy ${{ matrix.c_compiler }} ${{ matrix.extra_deps }} make pkg-config zlib-devel openssl-devel libarchive-devel kyua atf-devel
          - name: Build
@@ -32,4 +43,5 @@ jobs:
            run: |
               ./configure --enable-tests
               make -j
-         - run: make check
+         - name: Check
+           run: make check

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,48 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    - cron: '0 0 * * 0'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    container:
+      image: ghcr.io/void-linux/void-linux:20220530rc01-full-x86_64
+    steps:
+    - name: Prepare container
+      run: |
+        xbps-install -Syu || xbps-install -yu xbps
+        # node-based actions require libstdc++.so.6
+        xbps-install -Sy \
+          libstdc++ git \
+          gcc make pkg-config zlib-devel openssl-devel libarchive-devel
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - run: git config --global --add safe.directory $(pwd)
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: cpp
+        config-file: ./.github/codeql/codeql-config.yaml
+    - name: Build xbps
+      run: |
+          ./configure
+          make -j
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:cpp"


### PR DESCRIPTION
As of today, LGTM will [no longer be reviewing pull requests](https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/), and will shut down fully on 16 December. Github now runs the same service built-in as CodeQL, and integrates it into the [security tab](https://github.com/void-linux/xbps/security) of the repo.

I've replicated the LGTM setup to the best of my knowledge.

cc: @void-linux/xbps-developers 

(also includes a couple improvements to the build/test workflow I noticed)