### PR TITLE
manpages: small formatting improvements

### DIFF
--- a/bin/xbps-alternatives/xbps-alternatives.1
+++ b/bin/xbps-alternatives/xbps-alternatives.1
@@ -1,10 +1,11 @@
-.Dd June 20, 2019
+.Dd Feb 9, 2023
 .Dt XBPS-ALTERNATIVES 1
+.Os
 .Sh NAME
 .Nm xbps-alternatives
 .Nd XBPS utility to handle alternatives
 .Sh SYNOPSIS
-.Nm xbps-alternatives
+.Nm
 .Op OPTIONS
 .Ar MODE
 .Sh DESCRIPTION
@@ -100,10 +101,11 @@ configuration option.
 .Xr xbps-uunshare 1 ,
 .Xr xbps.d 5
 .Sh AUTHORS
-.An Juan Romero Pardines <xtraeme@gmail.com>
-.An Duncan Overbruck <mail@duncano.de>
+.An Juan Romero Pardines Aq Mt xtraeme@gmail.com
+.An Duncan Overbruck Aq Mt mail@duncano.de
 .Sh BUGS
 Probably, but I try to make this not happen. Use it under your own
 responsibility and enjoy your life.
 .Pp
-Report bugs at https://github.com/void-linux/xbps/issues
+Report bugs at
+.Lk https://github.com/void-linux/xbps/issues

--- a/bin/xbps-checkvers/xbps-checkvers.1
+++ b/bin/xbps-checkvers/xbps-checkvers.1
@@ -1,10 +1,11 @@
-.Dd June 20, 2019
+.Dd Feb 9, 2023
 .Dt XBPS-CHECKVERS 1
+.Os
 .Sh NAME
 .Nm xbps-checkvers
 .Nd XBPS utility to check for outdated packages
 .Sh SYNOPSIS
-.Nm xbps-checkvers
+.Nm
 .Op OPTIONS
 .Op FILES...
 .Sh DESCRIPTION
@@ -95,6 +96,7 @@ is printed instead.
 Show the version information.
 .El
 .Sh SEE ALSO
+.Xr xbps-alternatives 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
 .Xr xbps-digest 1 ,
@@ -109,11 +111,12 @@ Show the version information.
 .Xr xbps-uunshare 1 ,
 .Xr xbps.d 5
 .Sh AUTHORS
-.An Dave Elusive <davehome@redthumb.info.tm>
-.An Juan Romero Pardines <xtraeme@gmail.com>
-.An Duncan Overbruck <mail@duncano.de>
+.An Dave Elusive Aq Mt davehome@redthumb.info.tm
+.An Juan Romero Pardines Aq Mt xtraeme@gmail.com
+.An Duncan Overbruck Aq Mt mail@duncano.de
 .Sh BUGS
 Probably, but I try to make this not happen. Use it under your own
 responsibility and enjoy your life.
 .Pp
-Report bugs at https://github.com/void-linux/xbps/issues
+Report bugs at
+.Lk https://github.com/void-linux/xbps/issues

--- a/bin/xbps-create/xbps-create.1
+++ b/bin/xbps-create/xbps-create.1
@@ -1,10 +1,11 @@
-.Dd February 21, 2020
+.Dd Feb 9, 2023
 .Dt XBPS-CREATE 1
+.Os
 .Sh NAME
 .Nm xbps-create
 .Nd XBPS utility to create binary packages
 .Sh SYNOPSIS
-.Nm xbps-create
+.Nm
 .Op OPTIONS
 .Ar destdir
 .Sh DESCRIPTION
@@ -91,6 +92,7 @@ is a relative path, the symlink will be created relative to
 The package changelog string.
 .El
 .Sh SEE ALSO
+.Xr xbps-alternatives 1 ,
 .Xr xbps-checkvers 1 ,
 .Xr xbps-dgraph 1 ,
 .Xr xbps-digest 1 ,
@@ -106,9 +108,10 @@ The package changelog string.
 .Xr xbps-uunshare 1 ,
 .Xr xbps.d 5
 .Sh AUTHORS
-.An Juan Romero Pardines <xtraeme@gmail.com>
+.An Juan Romero Pardines Aq Mt xtraeme@gmail.com
 .Sh BUGS
 Probably, but I try to make this not happen. Use it under your own
 responsibility and enjoy your life.
 .Pp
-Report bugs at https://github.com/void-linux/xbps/issues
+Report bugs at
+.Lk https://github.com/void-linux/xbps/issues

--- a/bin/xbps-dgraph/xbps-dgraph.1
+++ b/bin/xbps-dgraph/xbps-dgraph.1
@@ -1,10 +1,11 @@
-.Dd June 12, 2019
+.Dd Feb 9, 2023
 .Dt XBPS-DGRAPH 1
+.Os
 .Sh NAME
 .Nm xbps-dgraph
 .Nd XBPS utility to generate package dot(1) graphs
 .Sh SYNOPSIS
-.Nm xbps-dgraph
+.Nm
 .Op OPTIONS
 .Ar MODE
 .Ar PKG
@@ -122,6 +123,7 @@ Default package database (0.38 format). Keeps track of installed packages and pr
 Default cache directory to store downloaded binary packages.
 .El
 .Sh SEE ALSO
+.Xr xbps-alternatives 1 ,
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-digest 1 ,
@@ -132,14 +134,15 @@ Default cache directory to store downloaded binary packages.
 .Xr xbps-query 1 ,
 .Xr xbps-reconfigure 1 ,
 .Xr xbps-remove 1 ,
-.Xr xbps-rindex  1 ,
+.Xr xbps-rindex 1 ,
 .Xr xbps-uchroot 1 ,
 .Xr xbps-uunshare 1 ,
 .Xr xbps.d 5
 .Sh AUTHORS
-.An Juan Romero Pardines <xtraeme@gmail.com>
+.An Juan Romero Pardines Aq Mt xtraeme@gmail.com
 .Sh BUGS
 Probably, but I try to make this not happen. Use it under your own
 responsibility and enjoy your life.
 .Pp
-Report bugs at https://github.com/void-linux/xbps/issues
+Report bugs at
+.Lk https://github.com/void-linux/xbps/issues

--- a/bin/xbps-digest/xbps-digest.1
+++ b/bin/xbps-digest/xbps-digest.1
@@ -1,10 +1,11 @@
-.Dd June 12, 2019
+.Dd Feb 9, 2023
 .Dt XBPS-DIGEST 1
+.Os
 .Sh NAME
 .Nm xbps-digest
 .Nd XBPS utility to generate message digests
 .Sh SYNOPSIS
-.Nm xbps-digest
+.Nm
 .Op OPTIONS
 .Op FILE
 .Op FILE+N
@@ -29,6 +30,7 @@ Show the help message.
 Show the version information.
 .El
 .Sh SEE ALSO
+.Xr xbps-alternatives 1 ,
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
@@ -39,14 +41,15 @@ Show the version information.
 .Xr xbps-query 1 ,
 .Xr xbps-reconfigure 1 ,
 .Xr xbps-remove 1 ,
-.Xr xbps-rindex  1 ,
+.Xr xbps-rindex 1 ,
 .Xr xbps-uchroot 1 ,
 .Xr xbps-uunshare 1 ,
 .Xr xbps.d 5
 .Sh AUTHORS
-.An Juan Romero Pardines <xtraeme@gmail.com>
+.An Juan Romero Pardines Aq Mt xtraeme@gmail.com
 .Sh BUGS
 Probably, but I try to make this not happen. Use it under your own
 responsibility and enjoy your life.
 .Pp
-Report bugs at https://github.com/void-linux/xbps/issues
+Report bugs at
+.Lk https://github.com/void-linux/xbps/issues

--- a/bin/xbps-fbulk/xbps-fbulk.1
+++ b/bin/xbps-fbulk/xbps-fbulk.1
@@ -1,10 +1,11 @@
 .Dd April 20, 2020
 .Dt XBPS-FBULK 1
+.Os
 .Sh NAME
 .Nm xbps-fbulk
 .Nd XBPS utility to perform a fast bulk build of void-packages
 .Sh SYNOPSIS
-.Nm xbps-fbulk
+.Nm
 .Op OPTIONS
 .Ar /path/to/void-packages
 .Op pkgN pkg+N ...
@@ -93,6 +94,7 @@ has rights to execute
 and the kernel supports the overlay filesystem, introduced in 4.0.
 .Pp
 .Sh SEE ALSO
+.Xr xbps-alternatives 1 ,
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
@@ -111,14 +113,15 @@ and the kernel supports the overlay filesystem, introduced in 4.0.
 The
 .Nm
 utility was originally written by
-.An Matthew Dillon <dillon@backplane.com>
+.An Matthew Dillon Aq Mt dillon@backplane.com
 for the
 .Ar DragonFlyBSD project.
 .Pp
-.An Juan Romero Pardines <xtraeme@gmail.com>
+.An Juan Romero Pardines Aq Mt xtraeme@gmail.com
 adapted it for xbps and added some new features.
 .Sh BUGS
 Probably, but I try to make this not happen. Use it under your own
 responsibility and enjoy your life.
 .Pp
-Report bugs at https://github.com/void-linux/xbps/issues
+Report bugs at
+.Lk https://github.com/void-linux/xbps/issues

--- a/bin/xbps-fetch/xbps-fetch.1
+++ b/bin/xbps-fetch/xbps-fetch.1
@@ -1,10 +1,11 @@
-.Dd March 3, 2020
+.Dd Feb 9, 2023
 .Dt XBPS-FETCH 1
+.Os
 .Sh NAME
 .Nm xbps-fetch
 .Nd XBPS utility to fetch files from URLs
 .Sh SYNOPSIS
-.Nm xbps-fetch
+.Nm
 .Op OPTIONS
 .Ar <URL>
 .Ar <URL+N>
@@ -88,6 +89,7 @@ instead of default value of 5 minutes.
 When -1, waits indefinitely.
 .El
 .Sh SEE ALSO
+.Xr xbps-alternatives 1 ,
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
@@ -98,14 +100,15 @@ When -1, waits indefinitely.
 .Xr xbps-query 1 ,
 .Xr xbps-reconfigure 1 ,
 .Xr xbps-remove 1 ,
-.Xr xbps-rindex  1 ,
+.Xr xbps-rindex 1 ,
 .Xr xbps-uchroot 1 ,
 .Xr xbps-uunshare 1 ,
 .Xr xbps.d 5
 .Sh AUTHORS
-.An Juan Romero Pardines <xtraeme@gmail.com>
+.An Juan Romero Pardines Aq Mt xtraeme@gmail.com
 .Sh BUGS
 Probably, but I try to make this not happen.
 Use it under your own responsibility and enjoy your life.
 .Pp
-Report bugs at https://github.com/void-linux/xbps/issues
+Report bugs at
+.Lk https://github.com/void-linux/xbps/issues

--- a/bin/xbps-install/xbps-install.1
+++ b/bin/xbps-install/xbps-install.1
@@ -1,11 +1,11 @@
-.Dd April 23, 2020
+.Dd Feb 9, 2023
 .Dt XBPS-INSTALL 1
 .Os
 .Sh NAME
 .Nm xbps-install
 .Nd XBPS utility to (re)install and update packages
 .Sh SYNOPSIS
-.Nm xbps-install
+.Nm
 .Op OPTIONS
 .Op PKG...
 .Sh DESCRIPTION
@@ -267,6 +267,7 @@ Default trusted keys directory.
 Default cache directory to store downloaded binary packages.
 .El
 .Sh SEE ALSO
+.Xr xbps-alternatives 1 ,
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
@@ -282,10 +283,11 @@ Default cache directory to store downloaded binary packages.
 .Xr xbps-uunshare 1 ,
 .Xr xbps.d 5
 .Sh AUTHORS
-.An Juan Romero Pardines <xtraeme@gmail.com>
+.An Juan Romero Pardines Aq Mt xtraeme@gmail.com
 .Sh BUGS
 Probably, but I try to make this not happen.
 Use it under your own
 responsibility and enjoy your life.
 .Pp
-Report bugs at https://github.com/void-linux/xbps/issues
+Report bugs at
+.Lk https://github.com/void-linux/xbps/issues

--- a/bin/xbps-pkgdb/xbps-pkgdb.1
+++ b/bin/xbps-pkgdb/xbps-pkgdb.1
@@ -1,10 +1,11 @@
-.Dd June 20, 2019
+.Dd Feb 9, 2023
 .Dt XBPS-PKGDB 1
+.Os
 .Sh NAME
 .Nm xbps-pkgdb
 .Nd XBPS utility to report/fix issues and modify the package database (pkgdb)
 .Sh SYNOPSIS
-.Nm xbps-pkgdb
+.Nm
 .Op OPTIONS
 .Op PKGNAME...
 .Sh DESCRIPTION
@@ -122,6 +123,7 @@ Default package database (0.38 format). Keeps track of installed packages and pr
 Default cache directory to store downloaded binary packages.
 .El
 .Sh SEE ALSO
+.Xr xbps-alternatives 1 ,
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
@@ -137,10 +139,11 @@ Default cache directory to store downloaded binary packages.
 .Xr xbps-uunshare 1 ,
 .Xr xbps.d 5
 .Sh AUTHORS
-.An Juan Romero Pardines <xtraeme@gmail.com>
-.An Duncan Overbruck <mail@duncano.de>
+.An Juan Romero Pardines Aq Mt xtraeme@gmail.com
+.An Duncan Overbruck Aq Mt mail@duncano.de
 .Sh BUGS
 Probably, but I try to make this not happen. Use it under your own
 responsibility and enjoy your life.
 .Pp
-Report bugs at https://github.com/void-linux/xbps/issues
+Report bugs at
+.Lk https://github.com/void-linux/xbps/issues

--- a/bin/xbps-query/xbps-query.1
+++ b/bin/xbps-query/xbps-query.1
@@ -1,10 +1,11 @@
-.Dd April 23, 2020
+.Dd Feb 9, 2023
 .Dt XBPS-QUERY 1
+.Os
 .Sh NAME
 .Nm xbps-query
 .Nd XBPS utility to query for package and repository information
 .Sh SYNOPSIS
-.Nm xbps-query
+.Nm
 .Op OPTIONS
 .Ar MODE
 .Op ARGUMENTS
@@ -382,6 +383,7 @@ Default package database (0.38 format). Keeps track of installed packages and pr
 Default cache directory to store downloaded binary packages.
 .El
 .Sh SEE ALSO
+.Xr xbps-alternatives 1 ,
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
@@ -397,9 +399,10 @@ Default cache directory to store downloaded binary packages.
 .Xr xbps-uunshare 1 ,
 .Xr xbps.d 5
 .Sh AUTHORS
-.An Juan Romero Pardines <xtraeme@gmail.com>
+.An Juan Romero Pardines Aq Mt xtraeme@gmail.com
 .Sh BUGS
 Probably, but I try to make this not happen.
 Use it under your own responsibility and enjoy your life.
 .Pp
-Report bugs at https://github.com/void-linux/xbps/issues
+Report bugs at
+.Lk https://github.com/void-linux/xbps/issues

--- a/bin/xbps-reconfigure/xbps-reconfigure.1
+++ b/bin/xbps-reconfigure/xbps-reconfigure.1
@@ -1,10 +1,11 @@
-.Dd June 12, 2019
+.Dd Feb 9, 2023
 .Dt XBPS-RECONFIGURE 1
+.Os
 .Sh NAME
 .Nm xbps-reconfigure
 .Nd XBPS utility to configure installed packages
 .Sh SYNOPSIS
-.Nm xbps-reconfigure
+.Nm
 .Op OPTIONS
 .Op PKGNAME...
 .Sh DESCRIPTION
@@ -105,6 +106,7 @@ Default package database (0.38 format). Keeps track of installed packages and pr
 Default cache directory to store downloaded binary packages.
 .El
 .Sh SEE ALSO
+.Xr xbps-alternatives 1 ,
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
@@ -120,9 +122,10 @@ Default cache directory to store downloaded binary packages.
 .Xr xbps-uunshare 1 ,
 .Xr xbps.d 5
 .Sh AUTHORS
-.An Juan Romero Pardines <xtraeme@gmail.com>
+.An Juan Romero Pardines Aq Mt xtraeme@gmail.com
 .Sh BUGS
 Probably, but I try to make this not happen. Use it under your own
 responsibility and enjoy your life.
 .Pp
-Report bugs at https://github.com/void-linux/xbps/issues
+Report bugs at
+.Lk https://github.com/void-linux/xbps/issues

--- a/bin/xbps-remove/xbps-remove.1
+++ b/bin/xbps-remove/xbps-remove.1
@@ -1,10 +1,10 @@
-.Dd June 12, 2019
+.Dd Feb 9, 2023
 .Dt XBPS-REMOVE 1
 .Sh NAME
 .Nm xbps-remove
 .Nd XBPS utility to remove packages
 .Sh SYNOPSIS
-.Nm xbps-remove
+.Nm
 .Op OPTIONS
 .Op PKGNAME...
 .Sh DESCRIPTION
@@ -131,6 +131,7 @@ Default package database (0.38 format). Keeps track of installed packages and pr
 Default cache directory to store downloaded binary packages.
 .El
 .Sh SEE ALSO
+.Xr xbps-alternatives 1 ,
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
@@ -146,9 +147,10 @@ Default cache directory to store downloaded binary packages.
 .Xr xbps-uunshare 1 ,
 .Xr xbps.d 5
 .Sh AUTHORS
-.An Juan Romero Pardines <xtraeme@gmail.com>
+.An Juan Romero Pardines Aq Mt xtraeme@gmail.com
 .Sh BUGS
 Probably, but I try to make this not happen. Use it under your own
 responsibility and enjoy your life.
 .Pp
-Report bugs at https://github.com/void-linux/xbps/issues
+Report bugs at
+.Lk https://github.com/void-linux/xbps/issues

--- a/bin/xbps-rindex/xbps-rindex.1
+++ b/bin/xbps-rindex/xbps-rindex.1
@@ -1,10 +1,11 @@
-.Dd February 21, 2020
+.Dd Feb 9, 2023
 .Dt XBPS-RINDEX 1
+.Os
 .Sh NAME
 .Nm xbps-rindex
 .Nd XBPS utility to manage local binary package repositories
 .Sh SYNOPSIS
-.Nm xbps-rindex
+.Nm
 .Op OPTIONS
 .Ar MODE
 .Op ARGUMENTS
@@ -96,6 +97,7 @@ If this is set, it will use this passphrase for the RSA private key when signing
 a repository. Otherwise it will ask you to enter the passphrase on the terminal.
 .El
 .Sh SEE ALSO
+.Xr xbps-alternatives 1 ,
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
@@ -111,10 +113,11 @@ a repository. Otherwise it will ask you to enter the passphrase on the terminal.
 .Xr xbps-uunshare 1 ,
 .Xr xbps.d 5
 .Sh AUTHORS
-.An Juan Romero Pardines <xtraeme@gmail.com>
-.An Enno Boland <gottox@voidlinux.org>
+.An Juan Romero Pardines Aq Mt xtraeme@gmail.com
+.An Enno Boland Aq Mt gottox@voidlinux.org
 .Sh BUGS
 Probably, but I try to make this not happen. Use it under your own
 responsibility and enjoy your life.
 .Pp
-Report bugs at https://github.com/void-linux/xbps/issues
+Report bugs at
+.Lk https://github.com/void-linux/xbps/issues

--- a/bin/xbps-uchroot/xbps-uchroot.1
+++ b/bin/xbps-uchroot/xbps-uchroot.1
@@ -1,10 +1,11 @@
-.Dd April 14, 2020
+.Dd Feb 9, 2023
 .Dt XBPS-UCHROOT 1
+.Os
 .Sh NAME
 .Nm xbps-uchroot
 .Nd XBPS utility to chroot and bind mount with Linux namespaces
 .Sh SYNOPSIS
-.Nm xbps-uchroot
+.Nm
 .Op OPTIONS
 .Ar CHROOTDIR
 .Ar COMMAND
@@ -92,6 +93,7 @@ other Operating Systems. The following kernel options must be enabled:
 .It Sy CONFIG_OVERLAY_FS
 .El
 .Sh SEE ALSO
+.Xr xbps-alternatives 1 ,
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
@@ -106,9 +108,10 @@ other Operating Systems. The following kernel options must be enabled:
 .Xr xbps-uunshare 1 ,
 .Xr xbps.d 5
 .Sh AUTHORS
-.An Juan Romero Pardines <xtraeme@gmail.com>
+.An Juan Romero Pardines Aq Mt xtraeme@gmail.com
 .Sh BUGS
 Probably, but I try to make this not happen. Use it under your own
 responsibility and enjoy your life.
 .Pp
-Report bugs at https://github.com/void-linux/xbps/issues
+Report bugs at
+.Lk https://github.com/void-linux/xbps/issues

--- a/bin/xbps-uunshare/xbps-uunshare.1
+++ b/bin/xbps-uunshare/xbps-uunshare.1
@@ -1,10 +1,11 @@
-.Dd June 12, 2019
+.Dd Feb 9, 2023
 .Dt XBPS-UUNSHARE 1
+.Os
 .Sh NAME
 .Nm xbps-uunshare
 .Nd XBPS utility to chroot and bind mount with Linux user namespaces
 .Sh SYNOPSIS
-.Nm xbps-uunshare
+.Nm
 .Op OPTIONS
 .Ar CHROOTDIR
 .Ar COMMAND
@@ -57,6 +58,7 @@ other Operating Systems. The following kernel options must be enabled:
 .It Sy CONFIG_UTS_NS
 .El
 .Sh SEE ALSO
+.Xr xbps-alternatives 1 ,
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
@@ -71,9 +73,10 @@ other Operating Systems. The following kernel options must be enabled:
 .Xr xbps-uchroot 1 ,
 .Xr xbps.d 5
 .Sh AUTHORS
-.An Juan Romero Pardines <xtraeme@gmail.com>
+.An Juan Romero Pardines Aq Mt xtraeme@gmail.com
 .Sh BUGS
 Probably, but I try to make this not happen. Use it under your own
 responsibility and enjoy your life.
 .Pp
-Report bugs at https://github.com/void-linux/xbps/issues
+Report bugs at
+.Lk https://github.com/void-linux/xbps/issues

--- a/data/xbps.d.5
+++ b/data/xbps.d.5
@@ -1,5 +1,6 @@
-.Dd May 04, 2020
+.Dd Feb 9, 2023
 .Dt XBPS-D 5
+.Os
 .Sh NAME
 .Nm xbps.d
 .Nd XBPS configuration directory
@@ -171,6 +172,7 @@ Default cache directory to store downloaded binary packages.
 Annotated sample configuration file.
 .El
 .Sh SEE ALSO
+.Xr xbps-alternatives 1 ,
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,
 .Xr xbps-dgraph 1 ,
@@ -183,11 +185,13 @@ Annotated sample configuration file.
 .Xr xbps-reconfigure 1 ,
 .Xr xbps-remove 1 ,
 .Xr xbps-rindex 1 ,
-.Xr xbps-uchroot 1
+.Xr xbps-uchroot 1 ,
+.Xr xbps-uunshare 1
 .Sh AUTHORS
-.An Juan Romero Pardines <xtraeme@gmail.com>
+.An Juan Romero Pardines Aq Mt xtraeme@gmail.com
 .Sh BUGS
 Probably, but I try to make this not happen. Use it under your own
 responsibility and enjoy your life.
 .Pp
-Report bugs at https://github.com/void-linux/xbps/issues
+Report bugs at
+.Lk https://github.com/void-linux/xbps/issues


### PR DESCRIPTION
- use `.Os` to show "Void Linux" in the footer
- use `Aq Mt` to display email addresses
- use `.Lk` for the bug link
- remove unnecessary use of `.Nm <name>` when already defined
- add xbps-alternatives(1) to SEE ALSO where missing
- bump date
