### PR TITLE
bin/xbps-uhelper: allow multiple arguments for many actions

### DIFF
--- a/bin/xbps-uhelper/main.c
+++ b/bin/xbps-uhelper/main.c
@@ -46,7 +46,7 @@ usage(void)
 	"  Available actions:\n"
 	"    binpkgarch, binpkgver, cmpver, fetch, getpkgdepname,\n"
 	"    getpkgname, getpkgrevision, getpkgversion, pkgmatch, version,\n"
-	"    real-version, arch, getsystemdir\n"
+	"    real-version, arch, getsystemdir, getname, getversion\n"
 	"\n"
 	"  Action arguments:\n"
 	"    binpkgarch\t<binpkg> ...\n"
@@ -57,6 +57,8 @@ usage(void)
 	"    getpkgname\t\t<string> ...\n"
 	"    getpkgrevision\t<string> ...\n"
 	"    getpkgversion\t<string> ...\n"
+	"    getname\t\t<string> ...\n"
+	"    getversion\t\t<string> ...\n"
 	"    pkgmatch\t\t<pkg-version> <pkg-pattern>\n"
 	"    version\t\t<pkgname> ...\n"
 	"    real-version\t<pkgname> ...\n"
@@ -256,6 +258,41 @@ main(int argc, char **argv)
 			} else {
 				printf("%s\n", version);
 			}
+		}
+	} else if (strcmp(argv[0], "getname") == 0) {
+		/* returns the name of a pkg strings or pkg patterns */
+		if (argc < 2)
+			usage();
+
+		for (i = 1; i < argc; i++) {
+			if (xbps_pkgpattern_name(pkgname, sizeof(pkgname), argv[i]) ||
+				xbps_pkg_name(pkgname, sizeof(pkgname), argv[i])) {
+				printf("%s\n", pkgname);
+			} else {
+				xbps_error_printf(
+					"Invalid string '%s', expected <string><comparator><version> "
+					"or <string>-<version>_<revision>\n", argv[i]);
+				rv = 1;
+			}
+		}
+	} else if (strcmp(argv[0], "getversion") == 0) {
+		/* returns the version of a pkg strings or pkg patterns */
+		if (argc < 2)
+			usage();
+
+		for (i = 1; i < argc; i++) {
+			version = xbps_pkgpattern_version(argv[i]);
+			if (version == NULL) {
+				version = xbps_pkg_version(argv[i]);
+				if (version == NULL) {
+					xbps_error_printf(
+						"Invalid string '%s', expected <string><comparator><version> "
+						"or <string>-<version>_<revision>\n", argv[i]);
+					rv = 1;
+					continue;
+				}
+			}
+			printf("%s\n", version);
 		}
 	} else if (strcmp(argv[0], "binpkgver") == 0) {
 		/* Returns the pkgver of binpkg strings */


### PR DESCRIPTION
- allow multiple arguments for many actions

Only implemented where it makes sense to, i.e., not `cmpver`, `pkgmatch`, `arch`, `getsystemdir`, `digest`, and `fetch`.

Tests show a large speed-up is possible when processing a large number of inputs (1718 in this case):

**Before**
```
xbps-query -Rp pkgver -s python  0.18s user 0.02s system 99% cpu 0.199 total
cut -d: -f1  0.00s user 0.00s system 0% cpu 0.198 total
xargs -n1 xbps-uhelper getpkgname > /dev/null  0.49s user 1.17s system 94% cpu 1.761 total
```
**After**
```
xbps-query -Rp pkgver -s python  0.17s user 0.03s system 99% cpu 0.200 total
cut -d: -f1  0.00s user 0.00s system 0% cpu 0.200 total
xargs ./bin/xbps-uhelper/xbps-uhelper getpkgname > /dev/null  0.00s user 0.00s system 1% cpu 0.197 total
```
(note the lack of `-n1` in the second one)

- add getname and getversion actions

These actions are kind of "meta" actions, combining getpkgdepname and getpkgname (and the respective version actions) so that a list of mixed pkgvers and package patterns can be interpreted. This uses the internal format check of `xbps_pkgpattern_{name,version}()` to allow for a fallback to `xbps_pkg_{name,version}()` for exact versions, then falls back to displaying an error message if that also fails.

----

this will also be somewhat intertwined with an `xbps-uhelper` manpage, like in #533