### PR TITLE
lib/verifysig.c: work around broken signatures with openssl>=3

### DIFF
--- a/configure
+++ b/configure
@@ -368,6 +368,7 @@ fi
 if [ "$CC" = "tcc" ]; then
 	echo "CFLAGS += -Wno-error" >>$CONFIG_MK
 fi
+echo "CFLAGS += -Wno-error=deprecated-declarations">>$CONFIG_MK
 
 # libfetch
 echo "CPPFLAGS +=	-I\$(TOPDIR)/lib/fetch" >>$CONFIG_MK


### PR DESCRIPTION
The main issue is that our signatures contain a sha1 id in the ASN1 but a sha256 checksum length and message.
Prior to openssl 3 this worked and the full sha256 checksum was used, because the ASN1 was decoded on the fly and the whole message is compared against the checksum.
With version 3 openssl switched to just compare hard coded prefixes and since our prefix is broken its not there.
So we work around this by also hard-coding our broken prefix and instead of using the RSA signature apis, we use the public key to decrypt the signature and compare the content manually with our broken prefix.

This is fucking cursed and uses the deprecated apis, but works. Doing this is not possible with the new api's can't use a public key to independently decrypt the signature.