### PR TITLE
bin/xbps-pkgdb: use -errno values for error states

### DIFF
--- a/bin/xbps-pkgdb/check.c
+++ b/bin/xbps-pkgdb/check.c
@@ -100,7 +100,7 @@ check_pkg_integrity(struct xbps_handle *xhp,
 			xbps_error_printf("%s: cannot read %s, ignoring...\n",
 			    pkgname, buf);
 			free(buf);
-			return -1;
+			return -ENOENT;
 		}
 		rv = xbps_file_sha256_check(buf, sha256);
 		free(buf);
@@ -112,7 +112,7 @@ check_pkg_integrity(struct xbps_handle *xhp,
 			xbps_object_release(filesd);
 			xbps_error_printf("%s: metadata file has been "
 			    "modified!\n", pkgname);
-			return 1;
+			return -rv;
 		}
 	}
 
@@ -135,5 +135,5 @@ do {								\
 
 #undef RUN_PKG_CHECK
 
-	return errors ? EXIT_FAILURE : EXIT_SUCCESS;
+	return errors;
 }

--- a/bin/xbps-pkgdb/main.c
+++ b/bin/xbps-pkgdb/main.c
@@ -183,9 +183,9 @@ main(int argc, char **argv)
 	} else {
 		for (i = optind; i < argc; i++) {
 			rv = check_pkg_integrity(&xh, NULL, argv[i]);
-			if (rv != 0)
+			if (rv < 0)
 				xbps_error_printf("Failed to check "
-				    "`%s': %s\n", argv[i], strerror(rv));
+				    "`%s': %s\n", argv[i], strerror(-rv));
 		}
 	}
 

--- a/lib/fetch/http.c
+++ b/lib/fetch/http.c
@@ -602,13 +602,12 @@ http_base64(const char *src)
 	    "0123456789+/";
 	char *str, *dst;
 	size_t l;
-	int t, r;
+	int t;
 
 	l = strlen(src);
 	if ((str = malloc(((l + 2) / 3) * 4 + 1)) == NULL)
 		return (NULL);
 	dst = str;
-	r = 0;
 
 	while (l >= 3) {
 		t = (src[0] << 16) | (src[1] << 8) | src[2];
@@ -617,7 +616,7 @@ http_base64(const char *src)
 		dst[2] = base64[(t >> 6) & 0x3f];
 		dst[3] = base64[(t >> 0) & 0x3f];
 		src += 3; l -= 3;
-		dst += 4; r += 4;
+		dst += 4;
 	}
 
 	switch (l) {
@@ -628,7 +627,6 @@ http_base64(const char *src)
 		dst[2] = base64[(t >> 6) & 0x3f];
 		dst[3] = '=';
 		dst += 4;
-		r += 4;
 		break;
 	case 1:
 		t = src[0] << 16;
@@ -636,7 +634,6 @@ http_base64(const char *src)
 		dst[1] = base64[(t >> 12) & 0x3f];
 		dst[2] = dst[3] = '=';
 		dst += 4;
-		r += 4;
 		break;
 	case 0:
 		break;


### PR DESCRIPTION
Use -errno values for error states when checking a package. This will give more relevant information than before, removes a message that is misleading in many cases, and allows for some minor simplification.

before:
```
$ doas xbps-pkgdb runit-void; echo $?
ERROR: runit-void: hash mismatch for /etc/runit/2.
ERROR: runit-void: files check FAILED.
Failed to check `runit-void': Operation not permitted
1
```

after:
```
$ doas xbps-pkgdb runit-void; echo $?
ERROR: runit-void: hash mismatch for /etc/runit/2.
ERROR: runit-void: files check FAILED.
1
```

this does not change the behaviour of `xbps-pkgdb -a`.

---

second commit is an unrelated change, but this is the first time CI has been run on clang 15 so it was caught there.
