### PR TITLE
bin/xbps-install: add --import-key arg for non-interactive key import

### DIFF
--- a/bin/xbps-install/state_cb.c
+++ b/bin/xbps-install/state_cb.c
@@ -155,6 +155,10 @@ state_cb(const struct xbps_state_cb_data *xscd, void *cbdata UNUSED)
 		printf("Fingerprint: %s\n", xscd->arg);
 		rv = yesno("Do you want to import this public key?");
 		break;
+	case XBPS_STATE_REPO_KEY_EXPECTED:
+		printf("%s\n", xscd->desc);
+		printf("Importing key with fingerprint: %s\n", xscd->arg);
+		break;
 	case XBPS_STATE_SHOW_INSTALL_MSG:
 		printf("%s: post-install message:\n", xscd->arg);
 		printf("========================================================================\n");

--- a/bin/xbps-install/xbps-install.1
+++ b/bin/xbps-install/xbps-install.1
@@ -123,8 +123,14 @@ Ignore detected file conflicts in a transaction.
 .It Fl i , Fl -ignore-conf-repos
 Ignore repositories defined in configuration files.
 Only repositories specified in the command line via
-.Ar --repository
+.Fl -repository
 will be used.
+.It Fl k , Fl -import-key Ar fingerprint
+Import the key with the specified
+.Ar fingerprint
+without confirmation.
+Specified keys will only be imported if the key is used by a remote repository and has not already been imported.
+This option can be specified multiple times.
 .It Fl M , Fl -memory-sync
 For remote repositories, the data is fetched and stored in memory for the current
 operation.

--- a/include/xbps.h.in
+++ b/include/xbps.h.in
@@ -316,6 +316,7 @@ extern "C" {
  * - XBPS_STATE_UNPACK_FAIL: package unpack has failed.
  * - XBPS_STATE_REPOSYNC_FAIL: syncing remote repositories has failed.
  * - XBPS_STATE_REPO_KEY_IMPORT: repository is signed and needs to import pubkey.
+ * - XBPS_STATE_REPO_KEY_EXPECTED: repository is signed and will import expected pubkey.
  * - XBPS_STATE_INVALID_DEP: package has an invalid dependency.
  * - XBPS_STATE_SHOW_INSTALL_MSG: package must show a post-install message.
  * - XBPS_STATE_SHOW_REMOVE_MSG: package must show a pre-remove message.
@@ -369,6 +370,7 @@ typedef enum xbps_state {
 	XBPS_STATE_REPOSYNC_FAIL,
 	XBPS_STATE_CONFIGURE_DONE,
 	XBPS_STATE_REPO_KEY_IMPORT,
+	XBPS_STATE_REPO_KEY_EXPECTED,
 	XBPS_STATE_INVALID_DEP,
 	XBPS_STATE_SHOW_INSTALL_MSG,
 	XBPS_STATE_SHOW_REMOVE_MSG,
@@ -1755,10 +1757,11 @@ xbps_array_t xbps_repo_get_pkg_revdeps(struct xbps_repo *repo, const char *pkg);
  * signed properly for this to work.
  *
  * @param[in] repo Pointer to the target xbps_repo structure.
+ * @param[in] expfps Proplib array of expected key fingerprints.
  *
  * @return 0 on success, an errno value otherwise.
  */
-int xbps_repo_key_import(struct xbps_repo *repo);
+int xbps_repo_key_import(struct xbps_repo *repo, xbps_array_t expfps);
 
 /**@}*/
 


### PR DESCRIPTION
_as requested by @the-maldridge_

see also: #336, #399

**This works around the security concerns brought up in those issues by ensuring that _only_ the requested keys are ever imported automatically, not blindly importing _any_ keys that would be prompted for importation.**

- lib/repo.c: add expected fingerprints argument to xbps_repo_key_import

This array is a list of key fingerprints that should be imported without confirmation upon importing keys for a signed repository. A new state_cb state is added to allow for showing a message or doing some action when importing these keys.

- bin/xbps-install: add --import-key arg for non-interactive key import

Allows the user to specify a list of key fingerprints that are expected and should be imported if encountered. This will be useful for scripted or other non-interactive situations, including in xbps-src (removing interaction during operations if the repodata in `hostdir/binpkgs` is signed), and bootstrapping new systems without needing to copy the `<fingerprint>.plist` files into place beforehand.

Prints a message when importing to ensure the user knows the key was imported:

```
# xbps-install -k '6e:a5:91:cc:71:99:18:32:75:dc:be:b4:f8:ac:dc:19' -R http://localhost:8000/ -R https://repo-fastly.voidlinux.org/current -r /tmp/xbps-test -S
[*] Updating repository `http://localhost:8000//x86_64-repodata' ...
x86_64-repodata: 2098B [avg rate: 500MB/s]
[*] Updating repository `https://repo-fastly.voidlinux.org/current/x86_64-repodata' ...
x86_64-repodata: 1849KB [avg rate: 597MB/s]
`http://localhost:8000/' repository has been RSA signed by "classabbyamp"
Importing key with fingerprint: 6e:a5:91:cc:71:99:18:32:75:dc:be:b4:f8:ac:dc:19
`https://repo-fastly.voidlinux.org/current' repository has been RSA signed by "Void Linux"
Fingerprint: 60:ae:0c:d6:f0:95:17:80:bc:93:46:7a:89:af:a3:2d
Do you want to import this public key? [Y/n]
```