### PR TITLE
README.md: fix static binary urls, replace mips with armv7

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,14 +128,14 @@ Good luck!
 
 Binaries for Linux compiled statically with the musl C library are available:
 
-* [aarch64](https://a-hel-fi.m.voidlinux.org/static/xbps-static-latest.aarch64-musl.tar.xz)
-* [armv6hf](https://a-hel-fi.m.voidlinux.org/static/xbps-static-latest.armv6l-musl.tar.xz)
-* [i686](https://a-hel-fi.m.voidlinux.org/static/xbps-static-latest.i686-musl.tar.xz)
-* [x86\_64](https://a-hel-fi.m.voidlinux.org/static/xbps-static-latest.x86_64-musl.tar.xz)
-* [mips32](https://a-hel-fi.m.voidlinux.org/static/xbps-static-latest.mips-musl.tar.xz)
+* [aarch64](https://repo-default.voidlinux.org/static/xbps-static-latest.aarch64-musl.tar.xz)
+* [armv6l](https://repo-default.voidlinux.org/static/xbps-static-latest.armv6l-musl.tar.xz)
+* [armv7l](https://repo-default.voidlinux.org/static/xbps-static-latest.armv7l-musl.tar.xz)
+* [i686](https://repo-default.voidlinux.org/static/xbps-static-latest.i686-musl.tar.xz)
+* [x86\_64](https://repo-default.voidlinux.org/static/xbps-static-latest.x86_64-musl.tar.xz)
 
 These builds are available on all official void mirrors, along with their
-*sha256* [checksums](https://a-hel-fi.m.voidlinux.org/static/sha256sums.txt).
+*sha256* [checksums](https://repo-default.voidlinux.org/static/sha256sums.txt).
 
 ### Usage instructions
 

--- a/data/repod-main.conf
+++ b/data/repod-main.conf
@@ -1,1 +1,1 @@
-repository=https://a-hel-fi.m.voidlinux.org/current
+repository=https://repo-default.voidlinux.org/current

--- a/data/xbps.conf
+++ b/data/xbps.conf
@@ -48,15 +48,7 @@
 
 ## REPOSITORY MIRRORS
 #
-# - https://beta.de.repo.voidlinux.org/current
-# - https://beta.de.repo.voidlinux.org/current/nonfree
-# - https://beta.de.repo.voidlinux.org/current/multilib
-# - https://beta.de.repo.voidlinux.org/current/multilib/nonfree
-#
-# - http://alpha.us.repo.voidlinux.org/current
-# - http://alpha.us.repo.voidlinux.org/current/nonfree
-# - http://alpha.us.repo.voidlinux.org/current/multilib
-# - http://alpha.us.repo.voidlinux.org/current/multilib/nonfree
+# For a complete list, see https://xmirror.voidlinux.org
 
 ## PRESERVING FILES
 #

--- a/data/xbps.d.5
+++ b/data/xbps.d.5
@@ -115,8 +115,8 @@ Note that remote repositories must be signed using
 .Xr xbps-rindex 1 ,
 example:
 .Pp
-.Bl -tag -compact -width repository=https://a-hel-fi.m.voidlinux.org/current
-.It Sy repository=https://a-hel-fi.m.voidlinux.org/current
+.Bl -tag -compact -width repository=https://repo-default.voidlinux.org/current
+.It Sy repository=https://repo-default.voidlinux.org/current
 .It Sy repository=/hostdir/binpkgs
 .El
 .It Sy rootdir=path


### PR DESCRIPTION
- README.md: fix static binary urls, replace mips with armv7
- data/: update listed mirror urls

should maybe remove these from the mirrors:
```
xbps-static-latest.mips-musl.tar.xz                26-Sep-2021 02:55             2324644
xbps-static-latest.mipsel-musl.tar.xz              26-Sep-2021 02:55             2454672
```
