### PR TITLE
Generalizing sha256-functions

### DIFF
--- a/TODO
+++ b/TODO
@@ -18,7 +18,4 @@ xbps-fetch:
  - configurable libfetch timeout
  - configurable number of connection retries
 
-xbps-digest:
- - blake2b support
-
 Issues listed at https://github.com/void-linux/xbps/issues

--- a/bin/xbps-create/main.c
+++ b/bin/xbps-create/main.c
@@ -528,7 +528,7 @@ ftw_cb(const char *fpath, const struct stat *sb, const struct dirent *dir UNUSED
 			xe->type = ENTRY_TYPE_FILES;
 		}
 
-		if (!xbps_file_sha256(xe->sha256, sizeof sha256, fpath))
+		if (!xbps_file_hash(XBPS_HASH_SHA256, xe->sha256, sizeof sha256, fpath))
 			die("failed to process hash for: %s", fpath);
 		xbps_dictionary_set_cstring(fileinfo, "sha256", xe->sha256);
 

--- a/bin/xbps-digest/main.c
+++ b/bin/xbps-digest/main.c
@@ -89,13 +89,13 @@ main(int argc, char **argv)
 	}
 
 	if (argc < 1) {
-		if (!xbps_file_sha256(sha256, sizeof sha256, "/dev/stdin"))
+		if (!xbps_file_hash(XBPS_HASH_SHA256, sha256, sizeof sha256, "/dev/stdin"))
 			exit(EXIT_FAILURE);
 
 		printf("%s\n", sha256);
 	} else {
 		for (int i = 0; i < argc; i++) {
-			if (!xbps_file_sha256(sha256, sizeof sha256, argv[i])) {
+			if (!xbps_file_hash(XBPS_HASH_SHA256, sha256, sizeof sha256, argv[i])) {
 				xbps_error_printf(
 				    "%s: couldn't get hash for %s (%s)\n",
 				progname, argv[i], strerror(errno));

--- a/bin/xbps-fetch/main.c
+++ b/bin/xbps-fetch/main.c
@@ -169,7 +169,7 @@ main(int argc, char **argv)
 		} else if (rv == 0) {
 			xbps_warn_printf("%s: %s: file is identical with remote.\n", progname, argv[i]);
 			if (shasum) {
-				if (!xbps_file_sha256_raw(digest, sizeof digest, filename)) {
+				if (!xbps_file_hash_raw(XBPS_HASH_SHA256, digest, sizeof digest, filename)) {
 					xbps_error_printf("%s: failed to hash: %s: %s\n",
 					    progname, filename, strerror(rv));
 					failure = true;

--- a/bin/xbps-pkgdb/check.c
+++ b/bin/xbps-pkgdb/check.c
@@ -102,7 +102,7 @@ check_pkg_integrity(struct xbps_handle *xhp,
 			free(buf);
 			return -ENOENT;
 		}
-		rv = xbps_file_sha256_check(buf, sha256);
+		rv = xbps_file_hash_check(XBPS_HASH_SHA256, buf, sha256);
 		free(buf);
 		if (rv == ENOENT) {
 			xbps_dictionary_remove(opkgd, "metafile-sha256");

--- a/bin/xbps-pkgdb/check_pkg_files.c
+++ b/bin/xbps-pkgdb/check_pkg_files.c
@@ -74,7 +74,7 @@ check_pkg_files(struct xbps_handle *xhp, const char *pkgname, void *arg)
 			path = xbps_xasprintf("%s/%s", xhp->rootdir, file);
 			xbps_dictionary_get_cstring_nocopy(obj,
 				"sha256", &sha256);
-			rv = xbps_file_sha256_check(path, sha256);
+			rv = xbps_file_hash_check(XBPS_HASH_SHA256, path, sha256);
 			switch (rv) {
 			case 0:
 				free(path);

--- a/bin/xbps-remove/clean-cache.c
+++ b/bin/xbps-remove/clean-cache.c
@@ -106,7 +106,7 @@ cleaner_cb(struct xbps_handle *xhp, xbps_object_t obj,
 	if (pkgd) {
 		xbps_dictionary_get_cstring_nocopy(pkgd,
 		    "filename-sha256", &rsha256);
-		r = xbps_file_sha256_check(binpkg, rsha256);
+		r = xbps_file_hash_check(XBPS_HASH_SHA256, binpkg, rsha256);
 		if (r == 0) {
 			/* hash matched */
 			return 0;

--- a/bin/xbps-rindex/index-add.c
+++ b/bin/xbps-rindex/index-add.c
@@ -334,7 +334,7 @@ index_add(struct xbps_handle *xhp, int args, int argmax, char **argv, bool force
 		 * 	- filename-size
 		 * 	- filename-sha256
 		 */
-		if (!xbps_file_sha256(sha256, sizeof sha256, pkg)) {
+		if (!xbps_file_hash(XBPS_HASH_SHA256, sha256, sizeof sha256, pkg)) {
 			xbps_object_release(binpkgd);
 			free(pkgver);
 			rv = EINVAL;

--- a/bin/xbps-rindex/index-clean.c
+++ b/bin/xbps-rindex/index-clean.c
@@ -80,7 +80,7 @@ idx_cleaner_cb(struct xbps_handle *xhp UNUSED,
 		 */
 		xbps_dictionary_get_cstring_nocopy(obj,
 				"filename-sha256", &sha256);
-		if (xbps_file_sha256_check(filen, sha256) != 0) {
+		if (xbps_file_hash_check(XBPS_HASH_SHA256, filen, sha256) != 0) {
 			if (!xbps_pkg_name(pkgname, sizeof(pkgname), pkgver))
 				goto out;
 			xbps_dictionary_remove(dest, pkgname);

--- a/bin/xbps-rindex/sign.c
+++ b/bin/xbps-rindex/sign.c
@@ -94,7 +94,7 @@ rsa_sign_file(RSA *rsa, const char *file,
 {
 	unsigned char digest[XBPS_SHA256_DIGEST_SIZE];
 
-	if (!xbps_file_sha256_raw(digest, sizeof digest, file))
+	if (!xbps_file_hash_raw(XBPS_HASH_SHA256, digest, sizeof digest, file))
 		return false;
 
 	if ((*sigret = calloc(1, RSA_size(rsa) + 1)) == NULL) {

--- a/bin/xbps-uhelper/main.c
+++ b/bin/xbps-uhelper/main.c
@@ -370,7 +370,7 @@ main(int argc, char **argv)
 			usage();
 
 		for (i = 1; i < argc; i++) {
-			if (!xbps_file_sha256(sha256, sizeof sha256, argv[i])) {
+			if (!xbps_file_hash(XBPS_HASH_SHA256, sha256, sizeof sha256, argv[i])) {
 				xbps_error_printf(
 				    "couldn't get hash for %s (%s)\n",
 				    argv[i], strerror(errno));

--- a/include/xbps.h.in
+++ b/include/xbps.h.in
@@ -1882,19 +1882,42 @@ char *xbps_xasprintf(const char *fmt, ...)__attribute__ ((format (printf, 1, 2))
  */
 bool xbps_mmap_file(const char *file, void **mmf, size_t *mmflen, size_t *filelen);
 
+/**
+ * @enum xbps_hash_algorithm
+ *
+ * Enum describing which algorithm should be used to hash
+ *
+ * - XBPS_HASH_SHA256: use sha256 hashing
+ * - XBPS_HASH_BLAKE2B256: use blake2b (256bit) hashing
+ */
 typedef enum xbps_hash_algorithm {
 	XBPS_HASH_SHA256,
 	XBPS_HASH_BLAKE2B256
 } xbps_hash_algorithm_t;
 
-int xbps_hash_size_raw(xbps_hash_algorithm_t type);
-
-int xbps_hash_size(xbps_hash_algorithm_t type);
+/**
+ * Represents the raw size of a digest (thus sha256 being 32bit)
+ *
+ * @param[in] algo Algorithm to describe
+ *
+ * @return Size in bytes
+ */
+int xbps_hash_size_raw(xbps_hash_algorithm_t algo);
 
 /**
- * Computes a sha256 hex digest into \a dst of size \a len
+ * Represents the hexstring-size including null-terminating byte of a digest (thus sha256 being 65bit)
+ *
+ * @param[in] algo Algorithm to describe
+ *
+ * @return Size in bytes
+ */
+int xbps_hash_size(xbps_hash_algorithm_t algo);
+
+/**
+ * Computes a hex digest into \a dst of size \a len
  * from file \a file.
  *
+ * @param[in] algo Hashing algorithm to use
  * @param[out] dst Destination buffer.
  * @param[in] len Size of \a dst must be at least XBPS_SHA256_LENGTH.
  * @param[in] file The file to read.
@@ -1904,9 +1927,10 @@ int xbps_hash_size(xbps_hash_algorithm_t type);
 bool xbps_file_hash(xbps_hash_algorithm_t algo, char *dst, size_t len, const char *file);
 
 /**
- * Computes a sha256 binary digest into \a dst of size \a len
+ * Computes a binary digest into \a dst of size \a len
  * from file \a file.
  *
+ * @param[in] algo Hashing algorithm to use
  * @param[out] dst Destination buffer.
  * @param[in] len Size of \a dst must be at least XBPS_SHA256_DIGEST_SIZE_LENGTH.
  * @param[in] file The file to read.
@@ -1916,16 +1940,17 @@ bool xbps_file_hash(xbps_hash_algorithm_t algo, char *dst, size_t len, const cha
 bool xbps_file_hash_raw(xbps_hash_algorithm_t algo, unsigned char *dst, unsigned int len, const char *file);
 
 /**
- * Compares the sha256 hash of the file \a file with the sha256
+ * Compares the hash of the file \a file with the sha256
  * string specified by \a sha256.
  *
+ * @param[in] algo Hashing algorithm to use
  * @param[in] file Path to a file.
- * @param[in] sha256 SHA256 hash to compare.
+ * @param[in] digest hash to compare.
  *
  * @return 0 if \a file and \a sha256 have the same hash, ERANGE
  * if it differs, or any other errno value on error.
  */
-int xbps_file_hash_check(xbps_hash_algorithm_t algo, const char *file, const char *sha256);
+int xbps_file_hash_check(xbps_hash_algorithm_t algo, const char *file, const char *digest);
 
 /**
  * Verifies the RSA signature \a sigfile against \a digest with the

--- a/include/xbps.h.in
+++ b/include/xbps.h.in
@@ -1882,6 +1882,15 @@ char *xbps_xasprintf(const char *fmt, ...)__attribute__ ((format (printf, 1, 2))
  */
 bool xbps_mmap_file(const char *file, void **mmf, size_t *mmflen, size_t *filelen);
 
+typedef enum xbps_hash_algorithm {
+	XBPS_HASH_SHA256,
+	XBPS_HASH_BLAKE2B256
+} xbps_hash_algorithm_t;
+
+int xbps_hash_size_raw(xbps_hash_algorithm_t type);
+
+int xbps_hash_size(xbps_hash_algorithm_t type);
+
 /**
  * Computes a sha256 hex digest into \a dst of size \a len
  * from file \a file.
@@ -1892,7 +1901,7 @@ bool xbps_mmap_file(const char *file, void **mmf, size_t *mmflen, size_t *filele
  *
  * @return true on success, false otherwise.
  */
-bool xbps_file_sha256(char *dst, size_t len, const char *file);
+bool xbps_file_hash(xbps_hash_algorithm_t algo, char *dst, size_t len, const char *file);
 
 /**
  * Computes a sha256 binary digest into \a dst of size \a len
@@ -1904,7 +1913,7 @@ bool xbps_file_sha256(char *dst, size_t len, const char *file);
  *
  * @return true on success, false otherwise.
  */
-bool xbps_file_sha256_raw(unsigned char *dst, size_t len, const char *file);
+bool xbps_file_hash_raw(xbps_hash_algorithm_t algo, unsigned char *dst, unsigned int len, const char *file);
 
 /**
  * Compares the sha256 hash of the file \a file with the sha256
@@ -1916,7 +1925,7 @@ bool xbps_file_sha256_raw(unsigned char *dst, size_t len, const char *file);
  * @return 0 if \a file and \a sha256 have the same hash, ERANGE
  * if it differs, or any other errno value on error.
  */
-int xbps_file_sha256_check(const char *file, const char *sha256);
+int xbps_file_hash_check(xbps_hash_algorithm_t algo, const char *file, const char *sha256);
 
 /**
  * Verifies the RSA signature \a sigfile against \a digest with the

--- a/lib/package_config_files.c
+++ b/lib/package_config_files.c
@@ -143,7 +143,7 @@ xbps_entry_install_conf_file(struct xbps_handle *xhp,
 		if (strcmp(entry_pname, buf)) {
 			continue;
 		}
-		if (!xbps_file_sha256(sha256_cur, sizeof sha256_cur, buf)) {
+		if (!xbps_file_hash(XBPS_HASH_SHA256, sha256_cur, sizeof sha256_cur, buf)) {
 			if (errno == ENOENT) {
 				/*
 				 * File not installed, install new one.

--- a/lib/package_register.c
+++ b/lib/package_register.c
@@ -86,7 +86,7 @@ xbps_register_pkg(struct xbps_handle *xhp, xbps_dictionary_t pkgrd)
 	 * Create a hash for the pkg's metafile if it exists.
 	 */
 	buf = xbps_xasprintf("%s/.%s-files.plist", xhp->metadir, pkgname);
-	if (xbps_file_sha256(sha256, sizeof sha256, buf)) {
+	if (xbps_file_hash(XBPS_HASH_SHA256, sha256, sizeof sha256, buf)) {
 		xbps_dictionary_set_cstring(pkgd, "metafile-sha256", sha256);
 	}
 	free(buf);

--- a/lib/repo.c
+++ b/lib/repo.c
@@ -58,7 +58,7 @@ xbps_repo_path_with_name(struct xbps_handle *xhp, const char *url, const char *n
 {
 	assert(xhp);
 	assert(url);
-	assert(strcmp(name, "repodata") == 0 || strcmp(name, "stagedata") == 0);
+	assert(strcmp(name, "repodata") == 0 || strcmp(name, "stagedata") == 0|| strcmp(name, "files") == 0);
 
 	return xbps_xasprintf("%s/%s-%s",
 	    url, xhp->target_arch ? xhp->target_arch : xhp->native_arch, name);

--- a/lib/transaction_fetch.c
+++ b/lib/transaction_fetch.c
@@ -80,7 +80,7 @@ verify_binpkg(struct xbps_handle *xhp, xbps_dictionary_t pkgd)
 		xbps_set_cb_state(xhp, XBPS_STATE_VERIFY, 0, pkgver,
 			"%s: verifying SHA256 hash...", pkgver);
 		xbps_dictionary_get_cstring_nocopy(pkgd, "filename-sha256", &sha256);
-		if ((rv = xbps_file_sha256_check(binfile, sha256)) != 0) {
+		if ((rv = xbps_file_hash_check(XBPS_HASH_SHA256, binfile, sha256)) != 0) {
 			xbps_set_cb_state(xhp, XBPS_STATE_VERIFY_FAIL, rv, pkgver,
 				"%s: SHA256 hash is not valid: %s", pkgver, strerror(rv));
 			return rv;

--- a/lib/transaction_files.c
+++ b/lib/transaction_files.c
@@ -312,7 +312,7 @@ collect_obsoletes(struct xbps_handle *xhp)
 		 * Skip unexisting files and keep files with hash mismatch.
 		 */
 		if (item->old.sha256 != NULL) {
-			rv = xbps_file_sha256_check(item->file, item->old.sha256);
+			rv = xbps_file_hash_check(XBPS_HASH_SHA256, item->file, item->old.sha256);
 			switch (rv) {
 			case 0:
 				/* hash matches, we can safely delete and/or overwrite it */

--- a/lib/util_hash.c
+++ b/lib/util_hash.c
@@ -37,6 +37,7 @@
 
 #include <openssl/evp.h>
 
+#include "xbps.h"
 #include "xbps_api_impl.h"
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
@@ -118,14 +119,35 @@ xbps_mmap_file(const char *file, void **mmf, size_t *mmflen, size_t *filelen)
 	return true;
 }
 
-bool
-xbps_file_sha256_raw(unsigned char *dst, unsigned int dstlen, const char *file) {
+static const EVP_MD*
+algorithm2epv_md(xbps_hash_algorithm_t type) {
+	switch (type) {
+		case XBPS_HASH_SHA256:
+			return EVP_sha256();
+		case XBPS_HASH_BLAKE2B256:
+			return EVP_blake2s256();
+	}
+	return NULL;
+}
+
+int
+xbps_hash_size_raw(xbps_hash_algorithm_t type) {
+	return EVP_MD_size(algorithm2epv_md(type));
+}
+
+int
+xbps_hash_size(xbps_hash_algorithm_t type) {
+	return EVP_MD_size(algorithm2epv_md(type)) * 2 + 1;
+}
+
+bool 
+xbps_file_hash_raw(xbps_hash_algorithm_t type, unsigned char *dst, unsigned int dstlen, const char *file) {
 	int fd;
 	ssize_t len;
 	char buf[65536];
 	EVP_MD_CTX *mdctx;
 
-	if ((int) dstlen < EVP_MD_size(EVP_sha256())) {
+	if ((int) dstlen < xbps_hash_size_raw(type)) {
 		errno = ENOBUFS;
 		return false;
 	}
@@ -136,7 +158,7 @@ xbps_file_sha256_raw(unsigned char *dst, unsigned int dstlen, const char *file) 
 	if((mdctx = EVP_MD_CTX_new()) == NULL)
 		return false;
 
-	if(EVP_DigestInit_ex(mdctx, EVP_sha256(), NULL) != 1)
+	if(EVP_DigestInit_ex(mdctx, algorithm2epv_md(type), NULL) != 1)
 		return false;
 
 	while ((len = read(fd, buf, sizeof(buf))) > 0)
@@ -154,7 +176,7 @@ xbps_file_sha256_raw(unsigned char *dst, unsigned int dstlen, const char *file) 
 }
 
 bool
-xbps_file_sha256(char *dst, size_t dstlen, const char *file)
+xbps_file_hash(xbps_hash_algorithm_t type, char *dst, size_t dstlen, const char *file)
 {
 	unsigned char digest[XBPS_SHA256_DIGEST_SIZE];
 
@@ -164,7 +186,7 @@ xbps_file_sha256(char *dst, size_t dstlen, const char *file)
 		return false;
 	}
 
-	if (!xbps_file_sha256_raw(digest, sizeof digest, file))
+	if (!xbps_file_hash_raw(type, digest, sizeof digest, file))
 		return false;
 
 	digest2string(digest, dst, XBPS_SHA256_DIGEST_SIZE);
@@ -173,7 +195,7 @@ xbps_file_sha256(char *dst, size_t dstlen, const char *file)
 }
 
 static bool
-sha256_digest_compare(const char *sha256, size_t shalen,
+hash_digest_compare(const char *sha256, size_t shalen,
 		const unsigned char *digest, size_t digestlen)
 {
 
@@ -207,17 +229,17 @@ sha256_digest_compare(const char *sha256, size_t shalen,
 }
 
 int
-xbps_file_sha256_check(const char *file, const char *sha256)
+xbps_file_hash_check(xbps_hash_algorithm_t type, const char *file, const char *sha256)
 {
 	unsigned char digest[XBPS_SHA256_DIGEST_SIZE];
 
 	assert(file != NULL);
 	assert(sha256 != NULL);
 
-	if (!xbps_file_sha256_raw(digest, sizeof digest, file))
+	if (!xbps_file_hash_raw(type, digest, sizeof digest, file))
 		return errno;
 
-	if (!sha256_digest_compare(sha256, strlen(sha256), digest, sizeof digest))
+	if (!hash_digest_compare(sha256, strlen(sha256), digest, sizeof digest))
 		return ERANGE;
 
 	return 0;
@@ -278,10 +300,10 @@ xbps_file_hash_check_dictionary(struct xbps_handle *xhp,
 	}
 
 	if (strcmp(xhp->rootdir, "/") == 0) {
-		rv = xbps_file_sha256_check(file, sha256d);
+		rv = xbps_file_hash_check(XBPS_HASH_SHA256, file, sha256d);
 	} else {
 		buf = xbps_xasprintf("%s/%s", xhp->rootdir, file);
-		rv = xbps_file_sha256_check(buf, sha256d);
+		rv = xbps_file_hash_check(XBPS_HASH_SHA256, buf, sha256d);
 		free(buf);
 	}
 	if (rv == 0)

--- a/lib/verifysig.c
+++ b/lib/verifysig.c
@@ -139,7 +139,7 @@ xbps_verify_file_signature(struct xbps_repo *repo, const char *fname)
 	unsigned char digest[XBPS_SHA256_DIGEST_SIZE];
 	bool val = false;
 
-	if (!xbps_file_sha256_raw(digest, sizeof digest, fname)) {
+	if (!xbps_file_hash_raw(XBPS_HASH_SHA256, digest, sizeof digest, fname)) {
 		xbps_dbg_printf("can't open file %s: %s\n", fname, strerror(errno));
 		return false;
 	}


### PR DESCRIPTION
Hey! I've resolved the deprecated SHA256_* functions with it's EVP_* functions. With that I've generalized all `xbps_file_sha256(...)` functions to `xbps_file_hash(XBPS_HASH_SHA256, ...)` thus making support for other hashes in e.g. xbps-digest more easy.