### PR TITLE
bin/xbps-query: improve argument parsing

### DIFF
--- a/bin/xbps-query/main.c
+++ b/bin/xbps-query/main.c
@@ -46,9 +46,9 @@ usage(bool fail)
 	    " -M, --memory-sync         Remote repository data is fetched and stored\n"
 	    "                           in memory, ignoring on-disk repodata archives\n"
 	    " -p, --property PROP[,...] Show properties for PKGNAME\n"
-	    " -R, --repository          Enable repository mode. This mode explicitly\n"
+	    " -R                        Enable repository mode. This mode explicitly\n"
 	    "                           looks for packages in repositories\n"
-	    "     --repository=<url>    Enable repository mode and add repository\n"
+	    "     --repository <url>    Enable repository mode and add repository\n"
 	    "                           to the top of the list. This option can be\n"
 	    "                           specified multiple times\n"
 	    "     --regex               Use Extended Regular Expressions to match\n"
@@ -93,7 +93,7 @@ main(int argc, char **argv)
 		{ "list-orphans", no_argument, NULL, 'O' },
 		{ "ownedby", no_argument, NULL, 'o' },
 		{ "property", required_argument, NULL, 'p' },
-		{ "repository", optional_argument, NULL, 'R' },
+		{ "repository", required_argument, NULL, 4 },
 		{ "rootdir", required_argument, NULL, 'r' },
 		{ "show", no_argument, NULL, 'S' },
 		{ "search", no_argument, NULL, 's' },
@@ -169,9 +169,6 @@ main(int argc, char **argv)
 			show_prop = true;
 			break;
 		case 'R':
-			if (optarg != NULL) {
-				xbps_repo_store(&xh, optarg);
-			}
 			repo_mode = true;
 			break;
 		case 'r':
@@ -206,6 +203,10 @@ main(int argc, char **argv)
 			break;
 		case 3:
 			list_repolock = opmode = true;
+			break;
+		case 4:
+			xbps_repo_store(&xh, optarg);
+			repo_mode = true;
 			break;
 		case '?':
 		default:

--- a/bin/xbps-query/main.c
+++ b/bin/xbps-query/main.c
@@ -77,7 +77,7 @@ usage(bool fail)
 int
 main(int argc, char **argv)
 {
-	const char *shortopts = "C:c:df:hHiLlMmOo:p:Rr:s:S:VvX:x:";
+	const char *shortopts = "C:c:dfhHiLlMmOop:Rr:sSVvXx";
 	const struct option longopts[] = {
 		{ "config", required_argument, NULL, 'C' },
 		{ "cachedir", required_argument, NULL, 'c' },
@@ -91,17 +91,17 @@ main(int argc, char **argv)
 		{ "memory-sync", no_argument, NULL, 'M' },
 		{ "list-manual-pkgs", no_argument, NULL, 'm' },
 		{ "list-orphans", no_argument, NULL, 'O' },
-		{ "ownedby", required_argument, NULL, 'o' },
+		{ "ownedby", no_argument, NULL, 'o' },
 		{ "property", required_argument, NULL, 'p' },
 		{ "repository", optional_argument, NULL, 'R' },
 		{ "rootdir", required_argument, NULL, 'r' },
-		{ "show", required_argument, NULL, 'S' },
-		{ "search", required_argument, NULL, 's' },
+		{ "show", no_argument, NULL, 'S' },
+		{ "search", no_argument, NULL, 's' },
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
-		{ "files", required_argument, NULL, 'f' },
-		{ "deps", required_argument, NULL, 'x' },
-		{ "revdeps", required_argument, NULL, 'X' },
+		{ "files", no_argument, NULL, 'f' },
+		{ "deps", no_argument, NULL, 'x' },
+		{ "revdeps", no_argument, NULL, 'X' },
 		{ "regex", no_argument, NULL, 0 },
 		{ "fulldeptree", no_argument, NULL, 1 },
 		{ "cat", required_argument, NULL, 2 },
@@ -135,7 +135,6 @@ main(int argc, char **argv)
 			flags |= XBPS_FLAG_DEBUG;
 			break;
 		case 'f':
-			pkg = optarg;
 			show_files = opmode = true;
 			break;
 		case 'H':
@@ -163,7 +162,6 @@ main(int argc, char **argv)
 			orphans = opmode = true;
 			break;
 		case 'o':
-			pkg = optarg;
 			own = opmode = true;
 			break;
 		case 'p':
@@ -180,11 +178,9 @@ main(int argc, char **argv)
 			rootdir = optarg;
 			break;
 		case 'S':
-			pkg = optarg;
 			show = opmode = true;
 			break;
 		case 's':
-			pkg = optarg;
 			pkg_search = opmode = true;
 			break;
 		case 'v':
@@ -194,11 +190,9 @@ main(int argc, char **argv)
 			printf("%s\n", XBPS_RELVER);
 			exit(EXIT_SUCCESS);
 		case 'x':
-			pkg = optarg;
 			show_deps = opmode = true;
 			break;
 		case 'X':
-			pkg = optarg;
 			show_rdeps = opmode = true;
 			break;
 		case 0:
@@ -222,20 +216,42 @@ main(int argc, char **argv)
 	argc -= optind;
 	argv += optind;
 
-	if (!argc && !opmode) {
-		usage(true);
-		/* NOTREACHED */
-	} else if (!opmode) {
+	if (!opmode) {
+		if (argc) {
 		/* show mode by default */
 		show = opmode = true;
-		pkg = *(argv++);
-		argc--;
+		} else {
+			/* no arguments */
+			usage(true);
+			/* NOTREACHED */
+		}
 	}
+
+	if (own || pkg_search || catfile || show || show_prop ||
+	     show_files || show_deps || show_rdeps) {
+		/* modes that require a PKG argument */
+		if (argc) {
+			pkg = *(argv++);
+			argc--;
+		} else {
+			xbps_error_printf("xbps-query: missing required argument PKG\n");
+			exit(EXIT_FAILURE);
+			/* NOTREACHED */
+		}
+	}
+
 	if (argc) {
 		/* trailing parameters */
-		usage(true);
+		xbps_error_printf("xbps-query: too many arguments: ");
+		while (argc) {
+			printf("%s ", *(argv++));
+			argc--;
+		}
+		printf("\n");
+		exit(EXIT_FAILURE);
 		/* NOTREACHED */
 	}
+
 	/*
 	 * Initialize libxbps.
 	 */

--- a/bin/xbps-query/xbps-query.1
+++ b/bin/xbps-query/xbps-query.1
@@ -109,8 +109,8 @@ section.
 Enable repository mode.
 This mode explicitly looks in repositories, rather
 than looking in the target root directory.
-.It Fl -repository=url
-Appends the specified repository to the top of the list.
+.It Fl -repository Ar url
+Enables repository mode and adds the specified repository to the top of the list.
 The
 .Ar url
 argument expects a URL to the repository for remote repositories or
@@ -190,7 +190,7 @@ Lists packages that are in repolock mode.
 See the
 .Em PACKAGE MODES
 section for more information.
-.It Fl o, Fl -ownedby Ar PATTERN [ Fl -repository ] [ Fl -regex ]
+.It Fl o, Fl -ownedby Ar PATTERN [ Fl R ] [ Fl -regex ]
 Search for installed package files by matching
 .Ar PATTERN .
 The
@@ -203,22 +203,22 @@ or an Extended Regular Expression as explained in
 .Fl -regex
 option is set).
 If the
-.Fl -repository
+.Fl R
 option is set, the matched
 .Ar PATTERN
 in repositories will be shown.
-.It Fl S, Fl -show Ar PKG [ Fl -repository ] [ Fl -property Ar PROP ]
+.It Fl S, Fl -show Ar PKG [ Fl R ] [ Fl -property Ar PROP ]
 Shows information of an installed package.
 This is the default mode if no other mode is set.
 If the
-.Fl -repository
+.Fl R
 option is set, the matched
 .Ar PKG
 in repositories will be shown.
 If a package property is specified with
 .Fl -property,
 only that property will be shown.
-.It Fl s, Fl -search Ar PATTERN [ Fl -repository ] [ Fl -property Ar PROP ] [ Fl -regex ]
+.It Fl s, Fl -search Ar PATTERN [ Fl R ] [ Fl -property Ar PROP ] [ Fl -regex ]
 Search for packages by matching
 .Ar PATTERN
 on its
@@ -238,30 +238,30 @@ all packages matching
 against
 .Ar PROP
 will be shown.
-.It Fl f, Fl -files Ar PKG [ Fl -repository ]
+.It Fl f, Fl -files Ar PKG [ Fl R ]
 Show the package files for
 .Ar PKG .
 If the
-.Fl -repository
+.Fl R
 option is set, the matched
 .Ar PKG
 in repositories will be shown.
-.It Fl x, Fl -deps Ar PKG [ Fl -repository ]
+.It Fl x, Fl -deps Ar PKG [ Fl R ]
 Show the required dependencies for
 .Ar PKG .
 Only direct dependencies are shown.
 To see a full dependency tree, also set
 .Fl -fulldeptree .
 If the
-.Fl -repository
+.Fl R
 option is set, the matched
 .Ar PKG
 in repositories will be shown.
-.It Fl X, Fl -revdeps Ar PKG [ Fl -repository ]
+.It Fl X, Fl -revdeps Ar PKG [ Fl R ]
 Show the reverse dependencies for
 .Ar PKG .
 If the
-.Fl -repository
+.Fl R
 option is set, the matched
 .Ar PKG
 in repositories will be shown.

--- a/data/_xbps
+++ b/data/_xbps
@@ -154,7 +154,7 @@ _xbps_query() {
 		{-p,--property=-}'[Show properties]:property:($_xbps_properties)' \
 		--regex'[Use Extended Regular Expressions to match]' \
 		--fulldeptree'[Full dependency tree for -x/--deps]' \
-		{-R,--repository}'[Enable repository mode]' \
+		-R'[Enable repository mode]' \
 		'*'--repository=-'[Add repository to the top of the list]:repository url:_files -/' \
 		- '(mode)' \
 		{-l,--list-pkgs}'[List installed packages]' \


### PR DESCRIPTION
makes the behaviour of the `-R`/`--repository` flags match what xbps-install et al. do, namely `-R <repo>` and `--repository <repo>` now work. Existing behaviours are preserved.

allows `PKG` argument to appear anywhere in `argv` for more flexible argument parsing. This is now a valid command, for example:
```
xbps-query -Rx --fulldeptree foo
```
This also improves some error messages instead of just printing the `usage()` naïvely.
