### PR TITLE
xbps-fetch: don't url-escape tilde character in path

### DIFF
--- a/lib/fetch/fetch.c
+++ b/lib/fetch/fetch.c
@@ -364,6 +364,7 @@ fetch_urlpath_safe(char x)
 	case '=':
 	case '/':
 	case ';':
+	case '~':
 	/* If something is already quoted... */
 	case '%':
 		return 1;


### PR DESCRIPTION
This prevents the tilde (`~`) character from being escaped as `%7e` in paths.

For example, this URL didn't previously resolve correctly...

```
http://www.cs.columbia.edu/~lennox/udptunnel/udptunnel-1.1.tar.gz
```

Fixes #606