### PR TITLE
bin/xbps-install/transaction: print consistently for dry run

### DIFF
--- a/bin/xbps-install/transaction.c
+++ b/bin/xbps-install/transaction.c
@@ -59,19 +59,12 @@ show_actions(xbps_object_iterator_t iter)
 		isize = dsize = 0;
 
 		xbps_dictionary_get_cstring_nocopy(obj, "pkgver", &pkgver);
-		printf("%s %s", pkgver, ttype2str(obj));
 		xbps_dictionary_get_cstring_nocopy(obj, "repository", &repoloc);
 		xbps_dictionary_get_cstring_nocopy(obj, "architecture", &arch);
-		if (repoloc && arch)
-			printf(" %s %s", arch, repoloc);
 		xbps_dictionary_get_uint64(obj, "installed_size", &isize);
 		xbps_dictionary_get_uint64(obj, "filename-size", &dsize);
-		if (isize)
-			printf(" %ju", isize);
-		if (dsize)
-			printf(" %ju", dsize);
 
-		printf("\n");
+		printf("%s %s %s %s %ju %ju\n", pkgver, ttype2str(obj), arch ? arch : "-", repoloc ? repoloc : "-", isize, dsize);
 	}
 }
 


### PR DESCRIPTION
this ensures there will always be 6 fields per line, making it possible to parse the output consistently. `arch` and `repository` default to `-`. `installed_size` and `filename-size` default to `0` to allow for easy tabulation.

example:

```
# before
linux-lts-6.6_1 update x86_64 /home/abi/void/packages/hostdir/binpkgs/test 560
# after
linux-lts-6.6_1 update x86_64 /home/abi/void/packages/hostdir/binpkgs/test 0 560
```

Fixes: #610
