### PR TITLE
bin/xbps-fbulk: fix transposed calloc args

### DIFF
--- a/bin/xbps-fbulk/main.c
+++ b/bin/xbps-fbulk/main.c
@@ -397,7 +397,7 @@ runBuilds(const char *bpath)
 static void
 addDepn(struct item *item, struct item *xitem)
 {
-	struct depn *depn = calloc(sizeof(*depn), 1);
+	struct depn *depn = calloc(1, sizeof(*depn));
 	char *logpath3;
 	FILE *fp;
 


### PR DESCRIPTION
This fixes a warning on gcc14 (compile failure with werror).

This was fixed in the master branch with https://github.com/void-linux/xbps/commit/4f8e07aa64c329d6a134af373edc45d2a4c8d9e1 and later changed to just a malloc in https://github.com/void-linux/xbps/commit/da2c104d1642611c6491bd4b1771de8524bf7731, but this was never backported to the 0.59.x branch.

I'm just leaving it as a calloc to not break stuff, if you want it to become a malloc, let me know.