### PR TITLE
clean up error handling/exit status

### DIFF
--- a/bin/xbps-alternatives/main.c
+++ b/bin/xbps-alternatives/main.c
@@ -353,6 +353,8 @@ main(int argc, char **argv)
 		}
 		if ((rv = xbps_alternatives_set(&xh, pkg, group)) == 0)
 			rv = xbps_pkgdb_update(&xh, true, false);
+		else
+			xbps_error_printf("failed to update alternatives group: %s\n", strerror(rv));
 	} else if (list_mode) {
 		/* list alternative groups */
 		if (repo_mode) {
@@ -368,12 +370,18 @@ main(int argc, char **argv)
 				    strerror(rv));
 				exit(EXIT_FAILURE);
 			}
-			if (xbps_dictionary_count(sd.result) > 0)
+			if (xbps_dictionary_count(sd.result) > 0) {
 				print_alternatives(&xh, sd.result, group, true);
-			else
+			} else {
+				xbps_error_printf("no alternatives groups found\n");
 				exit(EXIT_FAILURE);
+			}
 		} else {
 			rv = list_alternatives(&xh, pkg, group);
+			if (rv == ENOENT) {
+				xbps_error_printf("no alternatives groups found");
+				fprintf(stderr, pkg ? " for package %s\n" : "\n", pkg);
+			}
 		}
 	}
 

--- a/bin/xbps-alternatives/xbps-alternatives.1
+++ b/bin/xbps-alternatives/xbps-alternatives.1
@@ -99,6 +99,9 @@ Overrides the
 .Sy syslog=true|false
 configuration option.
 .El
+.Sh EXIT STATUS
+.Ex
+A descriptive error message will be printed to stderr.
 .Sh SEE ALSO
 .Xr xbps-checkvers 1 ,
 .Xr xbps-create 1 ,

--- a/bin/xbps-checkvers/xbps-checkvers.1
+++ b/bin/xbps-checkvers/xbps-checkvers.1
@@ -104,6 +104,9 @@ Enables the use of staged packages from remote repositories.
 .It Fl V, Fl -version
 Show the version information.
 .El
+.Sh EXIT STATUS
+.Ex
+A descriptive error message will be printed to stderr.
 .Sh EXAMPLES
 Show all packages in
 .Pa ~/void-packages ,

--- a/bin/xbps-create/xbps-create.1
+++ b/bin/xbps-create/xbps-create.1
@@ -93,6 +93,9 @@ A list of required shared libraries, separated by whitespaces. Example:
 .It Fl -sourcepkg Ar string
 The pkgver of the sourcepkg that was used to build this binary package.
 .El
+.Sh EXIT STATUS
+.Ex
+A descriptive error message will be printed to stderr.
 .Sh SEE ALSO
 .Xr xbps-alternatives 1 ,
 .Xr xbps-checkvers 1 ,

--- a/bin/xbps-dgraph/xbps-dgraph.1
+++ b/bin/xbps-dgraph/xbps-dgraph.1
@@ -122,6 +122,9 @@ Default package database (0.38 format). Keeps track of installed packages and pr
 .It Ar /var/cache/xbps
 Default cache directory to store downloaded binary packages.
 .El
+.Sh EXIT STATUS
+.Ex
+A descriptive error message will be printed to stderr.
 .Sh SEE ALSO
 .Xr xbps-alternatives 1 ,
 .Xr xbps-checkvers 1 ,

--- a/bin/xbps-digest/xbps-digest.1
+++ b/bin/xbps-digest/xbps-digest.1
@@ -29,6 +29,9 @@ Show the help message.
 .It Fl V, Fl -version
 Show the version information.
 .El
+.Sh EXIT STATUS
+.Ex
+A descriptive error message will be printed to stderr.
 .Sh SEE ALSO
 .Xr xbps-alternatives 1 ,
 .Xr xbps-checkvers 1 ,

--- a/bin/xbps-fbulk/main.c
+++ b/bin/xbps-fbulk/main.c
@@ -622,8 +622,10 @@ main(int argc, char **argv)
 	/*
 	 * Check masterdir is properly initialized.
 	 */
-	if ((bpath = realpath(argv[0], NULL)) == NULL)
+	if ((bpath = realpath(argv[0], NULL)) == NULL) {
+		xbps_error_printf("failed to initialize masterdir: %s\n", strerror(errno));
 		exit(EXIT_FAILURE);
+	}
 
 	blen = strlen(bpath) + strlen("/srcpkgs") + 1;
 	rpath = malloc(blen);
@@ -643,6 +645,7 @@ main(int argc, char **argv)
 	 */
 	if (LogDir == NULL) {
 		if (getcwd(cwd, sizeof(cwd)-1) == NULL) {
+			xbps_error_printf("failed to get current directory: %s\n", strerror(errno));
 			exit(EXIT_FAILURE);
 		}
 		tmp = xbps_xasprintf("%s/fbulk-log.%u", cwd, (unsigned)getpid());

--- a/bin/xbps-fbulk/xbps-fbulk.1
+++ b/bin/xbps-fbulk/xbps-fbulk.1
@@ -66,6 +66,9 @@ Packages that were not built because they had to be skipped (unsupported archite
 .It Ar logdir/deps
 Packages that were not built due to failed or missing dependencies.
 .El
+.Sh EXIT STATUS
+.Ex
+A descriptive error message will be printed to stderr.
 .Sh NOTES
 The
 .Ar masterdir

--- a/bin/xbps-fetch/xbps-fetch.1
+++ b/bin/xbps-fetch/xbps-fetch.1
@@ -88,6 +88,9 @@ Sets connection timeout in milliseconds
 instead of default value of 5 minutes.
 When -1, waits indefinitely.
 .El
+.Sh EXIT STATUS
+.Ex
+A descriptive error message will be printed to stderr.
 .Sh SEE ALSO
 .Xr xbps-alternatives 1 ,
 .Xr xbps-checkvers 1 ,

--- a/bin/xbps-uchroot/xbps-uchroot.1
+++ b/bin/xbps-uchroot/xbps-uchroot.1
@@ -74,6 +74,12 @@ This option is useful if some of
 are options passed to
 .Ar COMMAND .
 .El
+.Sh EXIT STATUS
+.Ex
+A descriptive error message will be printed to stderr if the error originates from
+.Nm .
+Otherwise, the error comes from
+.Ar COMMAND .
 .Sh SECURITY
 The
 .Nm

--- a/bin/xbps-uhelper/main.c
+++ b/bin/xbps-uhelper/main.c
@@ -38,7 +38,7 @@
 #include "../xbps-install/defs.h"
 
 static void __attribute__((noreturn))
-usage(void)
+usage(bool fail)
 {
 	fprintf(stdout,
 	    "Usage: xbps-uhelper [OPTIONS] [MODE] [ARGUMENTS]\n\n"
@@ -66,7 +66,7 @@ usage(void)
 	    " version <pkgname...>                 Prints version of installed packages\n"
 	    " getsystemdir                         Prints the system xbps.d directory\n"
 	    );
-	exit(EXIT_FAILURE);
+	exit(fail ? EXIT_FAILURE : EXIT_SUCCESS);
 }
 
 static char *
@@ -104,6 +104,9 @@ main(int argc, char **argv)
 
 	while ((c = getopt_long(argc, argv, "C:dr:vV", longopts, NULL)) != -1) {
 		switch (c) {
+		case 'h':
+			usage(false);
+			/* NOTREACHED */
 		case 'C':
 			confdir = optarg;
 			break;
@@ -120,17 +123,21 @@ main(int argc, char **argv)
 		case 'V':
 			printf("%s\n", XBPS_RELVER);
 			exit(EXIT_SUCCESS);
+			/* NOTREACHED */
 		case '?':
 		default:
-			usage();
+			usage(true);
+			/* NOTREACHED */
 		}
 	}
 
 	argc -= optind;
 	argv += optind;
 
-	if (argc < 1)
-		usage();
+	if (argc < 1) {
+		usage(true);
+		/* NOTREACHED */
+	}
 
 	memset(&xh, 0, sizeof(xh));
 
@@ -158,8 +165,10 @@ main(int argc, char **argv)
 
 	if (strcmp(argv[0], "version") == 0) {
 		/* Prints version of installed packages */
-		if (argc < 2)
-			usage();
+		if (argc < 2) {
+			usage(true);
+			/* NOTREACHED */
+		}
 
 		for (i = 1; i < argc; i++) {
 			if ((((dict = xbps_pkgdb_get_pkg(&xh, argv[i])) == NULL)) &&
@@ -173,8 +182,10 @@ main(int argc, char **argv)
 		}
 	} else if (strcmp(argv[0], "real-version") == 0) {
 		/* Prints version of installed real packages, not virtual */
-		if (argc < 2)
-			usage();
+		if (argc < 2) {
+			usage(true);
+			/* NOTREACHED */
+		}
 
 		for (i = 1; i < argc; i++) {
 			if ((dict = xbps_pkgdb_get_pkg(&xh, argv[i])) == NULL) {
@@ -187,8 +198,10 @@ main(int argc, char **argv)
 		}
 	} else if (strcmp(argv[0], "getpkgversion") == 0) {
 		/* Returns the version of pkg strings */
-		if (argc < 2)
-			usage();
+		if (argc < 2) {
+			usage(true);
+			/* NOTREACHED */
+		}
 
 		for (i = 1; i < argc; i++) {
 			version = xbps_pkg_version(argv[i]);
@@ -202,8 +215,10 @@ main(int argc, char **argv)
 		}
 	} else if (strcmp(argv[0], "getpkgname") == 0) {
 		/* Returns the name of pkg strings */
-		if (argc < 2)
-			usage();
+		if (argc < 2) {
+			usage(true);
+			/* NOTREACHED */
+		}
 
 		for (i = 1; i < argc; i++) {
 			if (!xbps_pkg_name(pkgname, sizeof(pkgname), argv[i])) {
@@ -216,8 +231,10 @@ main(int argc, char **argv)
 		}
 	} else if (strcmp(argv[0], "getpkgrevision") == 0) {
 		/* Returns the revision of pkg strings */
-		if (argc < 2)
-			usage();
+		if (argc < 2) {
+			usage(true);
+			/* NOTREACHED */
+		}
 
 		for (i = 1; i < argc; i++) {
 			version = xbps_pkg_revision(argv[1]);
@@ -229,8 +246,10 @@ main(int argc, char **argv)
 		}
 	} else if (strcmp(argv[0], "getpkgdepname") == 0) {
 		/* Returns the pkgname of dependencies */
-		if (argc < 2)
-			usage();
+		if (argc < 2) {
+			usage(true);
+			/* NOTREACHED */
+		}
 
 		for (i = 1; i < argc; i++) {
 			if (!xbps_pkgpattern_name(pkgname, sizeof(pkgname), argv[i])) {
@@ -242,8 +261,10 @@ main(int argc, char **argv)
 		}
 	} else if (strcmp(argv[0], "getpkgdepversion") == 0) {
 		/* returns the version of package pattern dependencies */
-		if (argc < 2)
-			usage();
+		if (argc < 2) {
+			usage(true);
+			/* NOTREACHED */
+		}
 
 		for (i = 1; i < argc; i++) {
 			version = xbps_pkgpattern_version(argv[i]);
@@ -256,8 +277,10 @@ main(int argc, char **argv)
 		}
 	} else if (strcmp(argv[0], "getname") == 0) {
 		/* returns the name of a pkg strings or pkg patterns */
-		if (argc < 2)
-			usage();
+		if (argc < 2) {
+			usage(true);
+			/* NOTREACHED */
+		}
 
 		for (i = 1; i < argc; i++) {
 			if (xbps_pkgpattern_name(pkgname, sizeof(pkgname), argv[i]) ||
@@ -272,8 +295,10 @@ main(int argc, char **argv)
 		}
 	} else if (strcmp(argv[0], "getversion") == 0) {
 		/* returns the version of a pkg strings or pkg patterns */
-		if (argc < 2)
-			usage();
+		if (argc < 2) {
+			usage(true);
+			/* NOTREACHED */
+		}
 
 		for (i = 1; i < argc; i++) {
 			version = xbps_pkgpattern_version(argv[i]);
@@ -291,8 +316,10 @@ main(int argc, char **argv)
 		}
 	} else if (strcmp(argv[0], "binpkgver") == 0) {
 		/* Returns the pkgver of binpkg strings */
-		if (argc < 2)
-			usage();
+		if (argc < 2) {
+			usage(true);
+			/* NOTREACHED */
+		}
 
 		for (i = 1; i < argc; i++) {
 			version = xbps_binpkg_pkgver(argv[i]);
@@ -306,8 +333,10 @@ main(int argc, char **argv)
 		}
 	} else if (strcmp(argv[0], "binpkgarch") == 0) {
 		/* Returns the arch of binpkg strings */
-		if (argc < 2)
-			usage();
+		if (argc < 2) {
+			usage(true);
+			/* NOTREACHED */
+		}
 
 		for (i = 1; i < argc; i++) {
 			version = xbps_binpkg_arch(argv[i]);
@@ -321,8 +350,10 @@ main(int argc, char **argv)
 		}
 	} else if (strcmp(argv[0], "pkgmatch") == 0) {
 		/* Matches a pkg with a pattern */
-		if (argc != 3)
-			usage();
+		if (argc != 3) {
+			usage(true);
+			/* NOTREACHED */
+		}
 		rv = xbps_pkgpattern_match(argv[1], argv[2]);
 		if (flags & XBPS_FLAG_VERBOSE) {
 			if (rv >= 0)
@@ -336,8 +367,10 @@ main(int argc, char **argv)
 		exit(rv);
 	} else if (strcmp(argv[0], "cmpver") == 0) {
 		/* Compare two version strings, installed vs required */
-		if (argc != 3)
-			usage();
+		if (argc != 3) {
+			usage(true);
+			/* NOTREACHED */
+		}
 
 		rv = xbps_cmpver(argv[1], argv[2]);
 		if (flags & XBPS_FLAG_VERBOSE)
@@ -348,8 +381,10 @@ main(int argc, char **argv)
 		exit(rv);
 	} else if (strcmp(argv[0], "arch") == 0) {
 		/* returns the xbps native arch */
-		if (argc != 1)
-			usage();
+		if (argc != 1) {
+			usage(true);
+			/* NOTREACHED */
+		}
 
 		if (xh.native_arch[0] && xh.target_arch && strcmp(xh.native_arch, xh.target_arch)) {
 			printf("%s\n", xh.target_arch);
@@ -358,16 +393,20 @@ main(int argc, char **argv)
 		}
 	} else if (strcmp(argv[0], "getsystemdir") == 0) {
 		/* returns the xbps system directory (<sharedir>/xbps.d) */
-		if (argc != 1)
-			usage();
+		if (argc != 1) {
+			usage(true);
+			/* NOTREACHED */
+		}
 
 		printf("%s\n", XBPS_SYSDEFCONF_PATH);
 	} else if (strcmp(argv[0], "digest") == 0) {
 		char sha256[XBPS_SHA256_SIZE];
 
 		/* Prints SHA256 hashes for specified files */
-		if (argc < 2)
-			usage();
+		if (argc < 2) {
+			usage(true);
+			/* NOTREACHED */
+		}
 
 		for (i = 1; i < argc; i++) {
 			if (!xbps_file_sha256(sha256, sizeof sha256, argv[i])) {
@@ -380,8 +419,10 @@ main(int argc, char **argv)
 		}
 	} else if (strcmp(argv[0], "fetch") == 0) {
 		/* Fetch a file from specified URL */
-		if (argc < 2)
-			usage();
+		if (argc < 2) {
+			usage(true);
+			/* NOTREACHED */
+		}
 
 		for (i = 1; i < argc; i++) {
 			filename = fname(argv[i]);
@@ -397,7 +438,7 @@ main(int argc, char **argv)
 			}
 		}
 	} else {
-		usage();
+		usage(true);
 	}
 
 	exit(rv ? EXIT_FAILURE : EXIT_SUCCESS);

--- a/bin/xbps-uhelper/xbps-uhelper.1
+++ b/bin/xbps-uhelper/xbps-uhelper.1
@@ -151,7 +151,8 @@ Prints the version of installed real packages.
 Prints the version of installed packages.
 .El
 .Sh EXIT STATUS
-.Ex -std
+.Ex
+A descriptive error message will be printed to stderr.
 Exceptions to this are:
 .Bl -tag -width xx
 .It Cm cmpver Ar instver Ar reqver

--- a/bin/xbps-uunshare/main.c
+++ b/bin/xbps-uunshare/main.c
@@ -180,7 +180,7 @@ main(int argc, char **argv)
 	if (chrootdir[0] != '/') {
 		char cwd[PATH_MAX-1];
 		if (getcwd(cwd, sizeof(cwd)) == NULL)
-			die("getcwd");
+			die("failed to get current directory");
 		chrootdir = xbps_xasprintf("%s/%s", cwd, chrootdir);
 	}
 
@@ -189,7 +189,7 @@ main(int argc, char **argv)
 	 */
 	if (unshare(CLONE_NEWUSER|CLONE_NEWNS|CLONE_NEWIPC|CLONE_NEWUTS) == -1) {
 		errval = 99;
-		die("unshare");
+		die("failed to unshare from the current namespace");
 	}
 	/*
 	 * Setup uid/gid user mappings and restrict setgroups().

--- a/bin/xbps-uunshare/xbps-uunshare.1
+++ b/bin/xbps-uunshare/xbps-uunshare.1
@@ -45,6 +45,20 @@ This option is useful if some of
 are options passed to
 .Ar COMMAND .
 .El
+.Sh EXIT STATUS
+.Ex
+A descriptive error message will be printed to stderr if the error originates from
+.Nm .
+
+.Bl -tag -width xxx -compact
+.It 99
+Failed to unshare from the current namespace
+.Po See
+.Sx NOTES Pc .
+.El
+
+Otherwise, the error comes from
+.Ar COMMAND .
 .Sh NOTES
 The
 .Nm


### PR DESCRIPTION
- **bin/xbps-alternatives: clean up error handling**
- **bin/xbps-checkvers: clean up error handling**
- **bin/xbps-create: clean up error handling**
- **bin/xbps-dgraph: clean up error handling**
- **bin/xbps-digest: clean up error handling**
- **bin/xbps-fbulk: clean up error handling**
- **bin/xbps-fetch: clean up error handling**
- **bin/xbps-uchroot: clean up error handling**
- **bin/xbps-uhelper: clean up error handling**
- **bin/xbps-uunshare: clean up error handling**

fixes: #463
fixes: #458

still working on xbps-install, xbps-query, xbps-remove, and xbps-reconfigure, as those are significantly more complex.
