### PR TITLE
Reduce allocations

### DIFF
--- a/bin/xbps-alternatives/main.c
+++ b/bin/xbps-alternatives/main.c
@@ -346,8 +346,11 @@ main(int argc, char **argv)
 		exit(EXIT_FAILURE);
 	}
 	if (set_mode) {
+		// XXX: xbps_pkgdb_init
+		(void)xbps_pkgdb_get_pkg(&xh, "foo");
+
 		/* in set mode pkgdb must be locked and flushed on success */
-		if ((rv = xbps_pkgdb_lock(&xh)) != 0) {
+		if (xbps_pkgdb_lock(&xh) < 0) {
 			xbps_error_printf("failed to lock pkgdb: %s\n", strerror(rv));
 			xbps_end(&xh);
 			exit(EXIT_FAILURE);

--- a/bin/xbps-alternatives/main.c
+++ b/bin/xbps-alternatives/main.c
@@ -349,6 +349,7 @@ main(int argc, char **argv)
 		/* in set mode pkgdb must be locked and flushed on success */
 		if ((rv = xbps_pkgdb_lock(&xh)) != 0) {
 			xbps_error_printf("failed to lock pkgdb: %s\n", strerror(rv));
+			xbps_end(&xh);
 			exit(EXIT_FAILURE);
 		}
 		if ((rv = xbps_alternatives_set(&xh, pkg, group)) == 0)
@@ -361,6 +362,7 @@ main(int argc, char **argv)
 			struct search_data sd = { 0 };
 			if ((sd.result = xbps_dictionary_create()) == NULL) {
 				xbps_error_printf("Failed to create dictionary: %s\n", strerror(errno));
+				xbps_end(&xh);
 				exit(EXIT_FAILURE);
 			}
 			sd.group = group;
@@ -368,12 +370,14 @@ main(int argc, char **argv)
 			if (rv != 0 && rv != ENOTSUP) {
 				fprintf(stderr, "Failed to initialize rpool: %s\n",
 				    strerror(rv));
+				xbps_end(&xh);
 				exit(EXIT_FAILURE);
 			}
 			if (xbps_dictionary_count(sd.result) > 0) {
 				print_alternatives(&xh, sd.result, group, true);
 			} else {
 				xbps_error_printf("no alternatives groups found\n");
+				xbps_end(&xh);
 				exit(EXIT_FAILURE);
 			}
 		} else {

--- a/bin/xbps-install/transaction.c
+++ b/bin/xbps-install/transaction.c
@@ -441,8 +441,8 @@ exec_transaction(struct xbps_handle *xhp, unsigned int maxcols, bool yes, bool d
 				goto proceed;
 			}
 		} else {
-			xbps_dbg_printf("Empty transaction dictionary: %s\n",
-			    strerror(errno));
+			xbps_error_printf("Unexpected error: %s (%d)\n",
+			    strerror(rv), rv);
 		}
 		goto out;
 	}

--- a/bin/xbps-rindex/index-add.c
+++ b/bin/xbps-rindex/index-add.c
@@ -183,6 +183,7 @@ repodata_commit(const char *repodir, const char *repoarch,
 			printf("index: added `%s' (%s).\n", pkgver, arch);
 			xbps_dictionary_set(index, pkgname, pkg);
 		}
+		xbps_object_iterator_release(iter);
 		stage = NULL;
 	}
 

--- a/bin/xbps-rindex/index-add.c
+++ b/bin/xbps-rindex/index-add.c
@@ -87,6 +87,7 @@ repodata_commit(const char *repodir, const char *repoarch,
 
 		for (unsigned int i = 0; i < xbps_array_count(pkgshlibs); i++) {
 			const char *shlib = NULL;
+			bool alloc = false;
 			xbps_array_t users;
 			xbps_array_get_cstring_nocopy(pkgshlibs, i, &shlib);
 			if (!xbps_dictionary_get(oldshlibs, shlib))
@@ -95,8 +96,11 @@ repodata_commit(const char *repodir, const char *repoarch,
 			if (!users) {
 				users = xbps_array_create();
 				xbps_dictionary_set(usedshlibs, shlib, users);
+				alloc = true;
 			}
 			xbps_array_add_cstring(users, pkgname);
+			if (alloc)
+				xbps_object_release(users);
 		}
 	}
 	xbps_object_iterator_release(iter);
@@ -156,8 +160,7 @@ repodata_commit(const char *repodir, const char *repoarch,
 			for (unsigned int i = 0; i < xbps_array_count(users); i++) {
 				const char *user = NULL;
 				xbps_array_get_cstring_nocopy(users, i, &user);
-				xbps_dictionary_remove(usedshlibs, shlib);
-				printf("%s%s",pre, user);
+				printf("%s%s", pre, user);
 				pre = ", ";
 			}
 			printf(")\n");

--- a/bin/xbps-rindex/index-clean.c
+++ b/bin/xbps-rindex/index-clean.c
@@ -128,17 +128,24 @@ cleanup_repo(struct xbps_handle *xhp, const char *repodir, struct xbps_repo *rep
 	xbps_object_release(allkeys);
 
 	if (xbps_dictionary_equals(index, repo->index) &&
-	    xbps_dictionary_equals(stage, repo->stage))
+	    xbps_dictionary_equals(stage, repo->stage)) {
+		xbps_object_release(index);
+		xbps_object_release(stage);
 		return 0;
+	}
 
 	r = repodata_flush(repodir, repoarch, index, stage, repo->idxmeta, compression);
 	if (r < 0) {
 		xbps_error_printf("failed to write repodata: %s\n", strerror(-r));
+		xbps_object_release(index);
+		xbps_object_release(stage);
 		return r;
 	}
 	printf("stage: %u packages registered.\n", xbps_dictionary_count(stage));
 	printf("index: %u packages registered.\n", xbps_dictionary_count(index));
-	return r;
+	xbps_object_release(index);
+	xbps_object_release(stage);
+	return 0;
 }
 
 /*
@@ -167,7 +174,7 @@ index_clean(struct xbps_handle *xhp, const char *repodir, const bool hashcheck, 
 			return 0;
 		}
 		xbps_error_printf("cannot read repository data: %s\n",
-		    strerror(errno));
+		    strerror(-r));
 		xbps_repo_unlock(repodir, arch, lockfd);
 		return EXIT_FAILURE;
 	}

--- a/doc/xbps_api_doxyfile.in
+++ b/doc/xbps_api_doxyfile.in
@@ -1527,7 +1527,7 @@ INCLUDE_FILE_PATTERNS  =
 # undefined via #undef or recursively expanded use the := operator
 # instead of the = operator.
 
-PREDEFINED             = SIMPLEQ_ENTRY
+PREDEFINED             = SIMPLEQ_ENTRY PRINTF_LIKE(x,y)=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then
 # this tag can be used to specify a list of macro names that should be expanded.

--- a/include/xbps.h.in
+++ b/include/xbps.h.in
@@ -32,6 +32,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include <inttypes.h>
+#include <errno.h>
 
 #include <xbps/xbps_array.h>
 #include <xbps/xbps_bool.h>
@@ -696,6 +697,20 @@ void xbps_dbg_printf_append(const char *, ...)__attribute__ ((format (printf, 1,
 void xbps_verbose_printf(const char *, ...) __attribute__ ((format (printf, 1, 2)));
 void xbps_error_printf(const char *, ...)__attribute__ ((format (printf, 1, 2)));
 void xbps_warn_printf(const char *, ...)__attribute__ ((format (printf, 1, 2)));
+
+/**
+ * @brief Prints formatted log message to stderr and returns error.
+ * @returns returns the specified error value \a r.
+ */
+int xbps_error_errno(int r, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
+
+/**
+ * @brief Log out of memory condition.
+ * @returns Returns `-ENOMEM`.
+ */
+#define xbps_error_oom()                                                       \
+	xbps_error_errno(ENOMEM, "%s:%d %s: out of memory\n", __FILE__,        \
+	        __LINE__, __func__)
 
 /**
  * Initialize the XBPS library with the following steps:

--- a/include/xbps.h.in
+++ b/include/xbps.h.in
@@ -50,7 +50,7 @@
  *
  * This header documents the full API for the XBPS Library.
  */
-#define XBPS_API_VERSION	"20250521"
+#define XBPS_API_VERSION	"20250629"
 
 #ifndef XBPS_VERSION
  #define XBPS_VERSION		"UNSET"
@@ -571,6 +571,10 @@ struct xbps_handle {
 	 * in the configuration file.
 	 */
 	xbps_array_t repositories;
+	/**
+	 * @private
+	 */
+	int lock_fd;
 	/**
 	 * @private
 	 */

--- a/include/xbps.h.in
+++ b/include/xbps.h.in
@@ -689,29 +689,6 @@ struct xbps_handle {
 	int flags;
 };
 
-extern int xbps_debug_level;
-extern int xbps_verbose_level;
-
-void xbps_dbg_printf(const char *, ...) __attribute__ ((format (printf, 1, 2)));
-void xbps_dbg_printf_append(const char *, ...)__attribute__ ((format (printf, 1, 2)));
-void xbps_verbose_printf(const char *, ...) __attribute__ ((format (printf, 1, 2)));
-void xbps_error_printf(const char *, ...)__attribute__ ((format (printf, 1, 2)));
-void xbps_warn_printf(const char *, ...)__attribute__ ((format (printf, 1, 2)));
-
-/**
- * @brief Prints formatted log message to stderr and returns error.
- * @returns returns the specified error value \a r.
- */
-int xbps_error_errno(int r, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
-
-/**
- * @brief Log out of memory condition.
- * @returns Returns `-ENOMEM`.
- */
-#define xbps_error_oom()                                                       \
-	xbps_error_errno(ENOMEM, "%s:%d %s: out of memory\n", __FILE__,        \
-	        __LINE__, __func__)
-
 /**
  * Initialize the XBPS library with the following steps:
  *
@@ -732,6 +709,69 @@ int xbps_init(struct xbps_handle *xhp);
  * @param[in] xhp Pointer to an xbps_handle struct.
  */
 void xbps_end(struct xbps_handle *xhp);
+
+/**@}*/
+
+/** @addtogroup log */
+/**@{*/
+
+/**
+ * @brief The Debug level.
+ */
+extern int xbps_debug_level;
+extern int xbps_verbose_level;
+
+#if __has_attribute(format)
+# define PRINTF_LIKE(a, b) __attribute__ ((format (printf, a, b)))
+#else
+# define PRINTF_LIKE(a, b) /* printflike */
+#endif
+
+/**
+ * @brief Prints debug messages to stderr.
+ * @param[in] fmt format specifier for the message.
+ */
+void xbps_dbg_printf(const char *fmt, ...) PRINTF_LIKE(1, 2);
+
+/**
+ * @brief Prints debug messages to stderr.
+ * @param[in] fmt format specifier for the message.
+ */
+void xbps_dbg_printf_append(const char *fmt, ...) PRINTF_LIKE(1, 2);
+
+/**
+ * @brief Prints messages to stderr if verbosity is enabled.
+ * @param[in] fmt format specifier for the message.
+ */
+void xbps_verbose_printf(const char *, ...) __attribute__ ((format (printf, 1, 2)));
+
+/**
+ * @brief Prints error messages to stderr.
+ * @param[in] fmt format specifier for the message.
+ */
+void xbps_error_printf(const char *fmt, ...) PRINTF_LIKE(1, 2);
+
+/**
+ * @brief Prints warning messages to stderr.
+ * @param[in] fmt format specifier for the message.
+ */
+void xbps_warn_printf(const char *fmt, ...) PRINTF_LIKE(1, 2);
+
+/**
+ * @brief Prints formatted log message to stderr and returns error.
+ * @param[in] r errno to be returned.
+ * @param[in] fmt format specifier for the error message.
+ * @returns returns the specified error value \a r.
+ */
+int xbps_error_errno(int r, const char *fmt, ...)  PRINTF_LIKE(2, 3);
+
+/**
+ * @brief Log out of memory condition.
+ * @returns Returns `-ENOMEM`.
+ */
+#define xbps_error_oom()                                                       \
+	xbps_error_errno(ENOMEM, "%s:%d %s: out of memory\n", __FILE__,        \
+	        __LINE__, __func__)
 
 /**@}*/
 

--- a/include/xbps/macro.h
+++ b/include/xbps/macro.h
@@ -6,6 +6,14 @@
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
 
+#if __has_builtin(__builtin_imaxabs)
+# define ABS(x) __builtin_imaxabs((x))
+#elif __has_builtin(__builtin_llabs)
+# define ABS(x) __builtin_llabs((x))
+#else
+# define ABS(x) ((x) > 0 ? (x) : -(x))
+#endif
+
 #define typeof(x) __typeof__(x)
 
 #define container_of(ptr, type, member)                                        \

--- a/include/xbps/macro.h
+++ b/include/xbps/macro.h
@@ -1,0 +1,27 @@
+#ifndef _XBPS_MACRO_H
+#define _XBPS_MACRO_H
+
+#define ARRAY_SIZE(x) (sizeof((x)) / sizeof((x))[0])
+
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+
+#define typeof(x) __typeof__(x)
+
+#define container_of(ptr, type, member)                                        \
+	({                                                                     \
+		const typeof(((type *)0)->member) *__mptr = ptr;               \
+		((type *)((uintptr_t)__mptr - offsetof(type, member)));        \
+	})
+
+#define struct_size(ptr, member, count)                                        \
+	((sizeof(*(ptr)->member) * (count)) + sizeof(*(ptr)))
+
+#define STRLEN(x) (sizeof("" x "") - sizeof(typeof(x[0])))
+
+#define streq(a, b)         (strcmp((a), (b)) == 0)
+#define strneq(a, b, n)     (strncmp((a), (b), (n)) == 0)
+#define strcaseeq(a, b)     (strcasecmp((a), (b)) == 0)
+#define strcaseneq(a, b, n) (strcasencmp((a), (b), (n)) == 0)
+
+#endif /* !_XBPS_MACRO_H */

--- a/include/xbps_api_impl.h
+++ b/include/xbps_api_impl.h
@@ -89,7 +89,7 @@ xbps_dictionary_t HIDDEN xbps_find_virtualpkg_in_array(struct xbps_handle *,
 bool HIDDEN xbps_transaction_check_revdeps(struct xbps_handle *, xbps_array_t);
 bool HIDDEN xbps_transaction_check_shlibs(struct xbps_handle *, xbps_array_t);
 bool HIDDEN xbps_transaction_check_replaces(struct xbps_handle *, xbps_array_t);
-bool HIDDEN xbps_transaction_check_conflicts(struct xbps_handle *, xbps_array_t);
+int HIDDEN xbps_transaction_check_conflicts(struct xbps_handle *, xbps_array_t);
 bool HIDDEN xbps_transaction_store(struct xbps_handle *, xbps_array_t, xbps_dictionary_t, bool);
 int HIDDEN xbps_transaction_init(struct xbps_handle *);
 int HIDDEN xbps_transaction_files(struct xbps_handle *,

--- a/lib/log.c
+++ b/lib/log.c
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <stdarg.h>
 
+#include "xbps/macro.h"
 #include "xbps_api_impl.h"
 
 #ifdef __clang__
@@ -111,4 +112,16 @@ xbps_warn_printf(const char *fmt, ...)
 	va_start(ap, fmt);
 	common_printf(stderr, "WARNING: ", fmt, ap);
 	va_end(ap);
+}
+
+int
+xbps_error_errno(int r, const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	common_printf(stderr, "ERROR: ", fmt, ap);
+	va_end(ap);
+
+	return -ABS(r);
 }

--- a/lib/pkgdb.c
+++ b/lib/pkgdb.c
@@ -296,9 +296,7 @@ xbps_pkgdb_init(struct xbps_handle *xhp)
 
 	if ((rv = xbps_pkgdb_update(xhp, false, true)) != 0) {
 		if (rv != ENOENT)
-			xbps_dbg_printf("[pkgdb] cannot internalize "
-			    "pkgdb dictionary: %s\n", strerror(rv));
-
+			xbps_error_printf("failed to initialize pkgdb: %s\n", strerror(rv));
 		return rv;
 	}
 	if ((rv = pkgdb_map_names(xhp)) != 0) {

--- a/lib/pkgdb.c
+++ b/lib/pkgdb.c
@@ -399,17 +399,19 @@ xbps_pkgdb_foreach_cb_multi(struct xbps_handle *xhp,
 		void *arg)
 {
 	xbps_array_t allkeys;
-	int rv;
+	int r;
 
 	// XXX: this should be done before calling the function...
 	if ((r = xbps_pkgdb_init(xhp)) != 0)
 		return r > 0 ? -r : r;
 
 	allkeys = xbps_dictionary_all_keys(xhp->pkgdb);
-	assert(allkeys);
-	rv = xbps_array_foreach_cb_multi(xhp, allkeys, xhp->pkgdb, fn, arg);
+	if (!allkeys)
+		return xbps_error_oom();
+
+	r = xbps_array_foreach_cb_multi(xhp, allkeys, xhp->pkgdb, fn, arg);
 	xbps_object_release(allkeys);
-	return rv;
+	return r;
 }
 
 xbps_dictionary_t

--- a/lib/pkgdb.c
+++ b/lib/pkgdb.c
@@ -382,16 +382,17 @@ xbps_pkgdb_foreach_cb(struct xbps_handle *xhp,
 		void *arg)
 {
 	xbps_array_t allkeys;
-	int rv;
+	int r;
 
-	if ((rv = xbps_pkgdb_init(xhp)) != 0)
-		return rv;
+	// XXX: this should be done before calling the function...
+	if ((r = xbps_pkgdb_init(xhp)) != 0)
+		return r > 0 ? -r : r;
 
 	allkeys = xbps_dictionary_all_keys(xhp->pkgdb);
 	assert(allkeys);
-	rv = xbps_array_foreach_cb(xhp, allkeys, xhp->pkgdb, fn, arg);
+	r = xbps_array_foreach_cb(xhp, allkeys, xhp->pkgdb, fn, arg);
 	xbps_object_release(allkeys);
-	return rv;
+	return r;
 }
 
 int
@@ -402,8 +403,9 @@ xbps_pkgdb_foreach_cb_multi(struct xbps_handle *xhp,
 	xbps_array_t allkeys;
 	int rv;
 
-	if ((rv = xbps_pkgdb_init(xhp)) != 0)
-		return rv;
+	// XXX: this should be done before calling the function...
+	if ((r = xbps_pkgdb_init(xhp)) != 0)
+		return r > 0 ? -r : r;
 
 	allkeys = xbps_dictionary_all_keys(xhp->pkgdb);
 	assert(allkeys);

--- a/lib/plist.c
+++ b/lib/plist.c
@@ -45,6 +45,7 @@ struct thread_data {
 	unsigned int slicecount;
 	int (*fn)(struct xbps_handle *, xbps_object_t, const char *, void *, bool *);
 	void *fn_arg;
+	int r;
 };
 
 /**
@@ -61,7 +62,7 @@ array_foreach_thread(void *arg)
 	xbps_object_t obj, pkgd;
 	struct thread_data *thd = arg;
 	const char *key;
-	int rv;
+	int r;
 	bool loop_done = false;
 	unsigned i = thd->start;
 	unsigned int end = i + thd->slicecount;
@@ -80,9 +81,11 @@ array_foreach_thread(void *arg)
 				pkgd = obj;
 				key = NULL;
 			}
-			rv = (*thd->fn)(thd->xhp, pkgd, key, thd->fn_arg, &loop_done);
-			if (rv != 0 || loop_done)
+			r = (*thd->fn)(thd->xhp, pkgd, key, thd->fn_arg, &loop_done);
+			if (r != 0 || loop_done) {
+				thd->r = r;
 				return NULL;
+			}
 		}
 		/* Reserve more elements to compute */
 		pthread_mutex_lock(thd->reserved_lock);
@@ -103,14 +106,14 @@ xbps_array_foreach_cb_multi(struct xbps_handle *xhp,
 {
 	struct thread_data *thd;
 	unsigned int arraycount, slicecount;
-	int rv = 0, error = 0, i, maxthreads;
+	int r, error = 0, i, maxthreads;
 	unsigned int reserved;
 	pthread_mutex_t reserved_lock = PTHREAD_MUTEX_INITIALIZER;
 
 	assert(fn != NULL);
 
 	if (xbps_object_type(array) != XBPS_TYPE_ARRAY)
-		return 0;
+		return -EINVAL;
 
 	arraycount = xbps_array_count(array);
 	if (arraycount == 0)
@@ -121,7 +124,8 @@ xbps_array_foreach_cb_multi(struct xbps_handle *xhp,
 		return xbps_array_foreach_cb(xhp, array, dict, fn, arg);
 
 	thd = calloc(maxthreads, sizeof(*thd));
-	assert(thd);
+	if (!thd)
+		return xbps_error_oom();
 
 	// maxthread is boundchecked to be > 1
 	if((unsigned int)maxthreads >= arraycount) {
@@ -148,22 +152,31 @@ xbps_array_foreach_cb_multi(struct xbps_handle *xhp,
 		thd[i].slicecount = slicecount;
 		thd[i].arraycount = arraycount;
 
-		if ((rv = pthread_create(&thd[i].thread, NULL, array_foreach_thread, &thd[i])) != 0) {
-			error = rv;
+		r = -pthread_create(&thd[i].thread, NULL, array_foreach_thread, &thd[i]);
+		if (r < 0) {
+			xbps_error_printf(
+			    "failed to create thread: %s\n", strerror(-r));
 			break;
 		}
-
 	}
+
+	// if we are unable to create any threads, just do single threaded.
+	if (i == 0)
+		return xbps_array_foreach_cb(xhp, array, dict, fn, arg);
+
 	/* wait for all threads that were created successfully */
 	for (int c = 0; c < i; c++) {
-		if ((rv = pthread_join(thd[c].thread, NULL)) != 0)
-			error = rv;
+		r = -pthread_join(thd[c].thread, NULL);
+		if (r < 0) {
+			xbps_error_printf(
+			    "failed to wait on thread: %s\n", strerror(-r));
+			error++;
+		}
 	}
 
-	free(thd);
 	pthread_mutex_destroy(&reserved_lock);
 
-	return error ? error : rv;
+	return error ? -EIO : 0;
 }
 
 int
@@ -176,7 +189,7 @@ xbps_array_foreach_cb(struct xbps_handle *xhp,
 	xbps_dictionary_t pkgd;
 	xbps_object_t obj;
 	const char *key;
-	int rv = 0;
+	int r = 0;
 	bool loop_done = false;
 
 	for (unsigned int i = 0; i < xbps_array_count(array); i++) {
@@ -191,11 +204,11 @@ xbps_array_foreach_cb(struct xbps_handle *xhp,
 			pkgd = obj;
 			key = NULL;
 		}
-		rv = (*fn)(xhp, pkgd, key, arg, &loop_done);
-		if (rv != 0 || loop_done)
-			break;
+		r = (*fn)(xhp, pkgd, key, arg, &loop_done);
+		if (r != 0 || loop_done)
+			return r;
 	}
-	return rv;
+	return 0;
 }
 
 xbps_object_iterator_t

--- a/lib/transaction_check_conflicts.c
+++ b/lib/transaction_check_conflicts.c
@@ -27,12 +27,11 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
 
 #include "xbps/xbps_array.h"
 #include "xbps_api_impl.h"
 
-static void
+static int
 pkg_conflicts_trans(struct xbps_handle *xhp, xbps_array_t array,
 		xbps_dictionary_t pkg_repod)
 {
@@ -47,23 +46,18 @@ pkg_conflicts_trans(struct xbps_handle *xhp, xbps_array_t array,
 	assert(pkg_repod);
 
 	pkg_cflicts = xbps_dictionary_get(pkg_repod, "conflicts");
-	if (xbps_array_count(pkg_cflicts) == 0) {
-		return;
-	}
+	if (xbps_array_count(pkg_cflicts) == 0)
+		return 0;
 
 	ttype = xbps_transaction_pkg_type(pkg_repod);
-	if (ttype == XBPS_TRANS_HOLD || ttype == XBPS_TRANS_REMOVE) {
-		return;
-	}
+	if (ttype == XBPS_TRANS_HOLD || ttype == XBPS_TRANS_REMOVE)
+		return 0;
 
 	trans_cflicts = xbps_dictionary_get(xhp->transd, "conflicts");
-	if (!xbps_dictionary_get_cstring_nocopy(pkg_repod, "pkgver", &repopkgver)) {
-		return;
-	}
-	if (!xbps_dictionary_get_cstring_nocopy(pkg_repod, "pkgname", &repopkgname)) {
-		return;
-	}
-
+	if (!xbps_dictionary_get_cstring_nocopy(pkg_repod, "pkgver", &repopkgver))
+		abort();
+	if (!xbps_dictionary_get_cstring_nocopy(pkg_repod, "pkgname", &repopkgname))
+		abort();
 
 	for (unsigned int i = 0; i < xbps_array_count(pkg_cflicts); i++) {
 		const char *pkgver = NULL, *pkgname = NULL, *cfpkg = NULL;
@@ -81,15 +75,13 @@ pkg_conflicts_trans(struct xbps_handle *xhp, xbps_array_t array,
 				continue;
 
 			/* Ignore itself */
-			if (!xbps_dictionary_get_cstring_nocopy(pkgd, "pkgname", &pkgname)) {
-				break;
-			}
+			if (!xbps_dictionary_get_cstring_nocopy(pkgd, "pkgname", &pkgname))
+				abort();
 			if (strcmp(pkgname, repopkgname) == 0) {
 				continue;
 			}
-			if (!xbps_dictionary_get_cstring_nocopy(pkgd, "pkgver", &pkgver)) {
-				break;
-			}
+			if (!xbps_dictionary_get_cstring_nocopy(pkgd, "pkgver", &pkgver))
+				abort();
 			/*
 			 * If there's a pkg for the conflict in transaction,
 			 * ignore it.
@@ -109,10 +101,8 @@ pkg_conflicts_trans(struct xbps_handle *xhp, xbps_array_t array,
 			buf = xbps_xasprintf("CONFLICT: %s with "
 			    "installed pkg %s (matched by %s)",
 			    repopkgver, pkgver, cfpkg);
-			if (!xbps_match_string_in_array(trans_cflicts, buf))
-				xbps_array_add_cstring(trans_cflicts, buf);
-
-			free(buf);
+			if (!xbps_array_add_cstring(trans_cflicts, buf))
+				return xbps_error_oom();
 			continue;
 		}
 		/*
@@ -122,32 +112,29 @@ pkg_conflicts_trans(struct xbps_handle *xhp, xbps_array_t array,
 		    (pkgd = xbps_find_virtualpkg_in_array(xhp, array, cfpkg, 0))) {
 			/* ignore pkgs to be removed or on hold */
 			ttype = xbps_transaction_pkg_type(pkgd);
-			if (ttype == XBPS_TRANS_REMOVE || ttype == XBPS_TRANS_HOLD) {
+			if (ttype == XBPS_TRANS_REMOVE || ttype == XBPS_TRANS_HOLD)
 				continue;
-			}
 			/* ignore itself */
-			if (!xbps_dictionary_get_cstring_nocopy(pkgd, "pkgname", &pkgname)) {
-				break;
-			}
-			if (strcmp(pkgname, repopkgname) == 0) {
+			if (!xbps_dictionary_get_cstring_nocopy(pkgd, "pkgname", &pkgname))
+				abort();
+			if (strcmp(pkgname, repopkgname) == 0)
 				continue;
-			}
-			if (!xbps_dictionary_get_cstring_nocopy(pkgd, "pkgver", &pkgver)) {
+			if (!xbps_dictionary_get_cstring_nocopy(pkgd, "pkgver", &pkgver))
 				break;
-			}
 			xbps_dbg_printf("found conflicting pkgs in "
 			    "transaction %s <-> %s (matched by %s [trans])\n",
 			    pkgver, repopkgver, cfpkg);
 			buf = xbps_xasprintf("CONFLICT: %s with "
 			   "%s in transaction (matched by %s)",
 			   repopkgver, pkgver, cfpkg);
-			if (!xbps_match_string_in_array(trans_cflicts, buf))
-				xbps_array_add_cstring(trans_cflicts, buf);
-
-			free(buf);
+			if (!buf)
+				return xbps_error_oom();
+			if (!xbps_array_add_cstring_nocopy(trans_cflicts, buf))
+				return xbps_error_oom();
 			continue;
 		}
 	}
+	return 0;
 }
 
 static int
@@ -159,23 +146,20 @@ pkgdb_conflicts_cb(struct xbps_handle *xhp, xbps_object_t obj,
 	xbps_trans_type_t ttype;
 	const char *repopkgver, *repopkgname;
 	char *buf;
-	int rv = 0;
 
 	pkg_cflicts = xbps_dictionary_get(obj, "conflicts");
 	if (xbps_array_count(pkg_cflicts) == 0)
 		return 0;
 
-	if (!xbps_dictionary_get_cstring_nocopy(obj, "pkgver", &repopkgver)) {
-		return EINVAL;
-	}
-	if (!xbps_dictionary_get_cstring_nocopy(obj, "pkgname", &repopkgname)) {
-		return EINVAL;
-	}
+	if (!xbps_dictionary_get_cstring_nocopy(obj, "pkgver", &repopkgver))
+		abort();
+	if (!xbps_dictionary_get_cstring_nocopy(obj, "pkgname", &repopkgname))
+		abort();
 
+	// XXX: this should really be a hashtable/dictionary lookup
 	/* if a pkg is in the transaction, ignore the one from pkgdb */
-	if (xbps_find_pkg_in_array(pkgs, repopkgname, 0)) {
+	if (xbps_find_pkg_in_array(pkgs, repopkgname, 0))
 		return 0;
-	}
 
 	trans_cflicts = xbps_dictionary_get(xhp->transd, "conflicts");
 
@@ -193,51 +177,52 @@ pkgdb_conflicts_cb(struct xbps_handle *xhp, xbps_object_t obj,
 				continue;
 			}
 			/* ignore itself */
-			if (!xbps_dictionary_get_cstring_nocopy(pkgd, "pkgname", &pkgname)) {
-				rv = EINVAL;
-				break;
-			}
+			if (!xbps_dictionary_get_cstring_nocopy(pkgd, "pkgname", &pkgname))
+				abort();
 			if (strcmp(pkgname, repopkgname) == 0) {
 				continue;
 			}
-			if (!xbps_dictionary_get_cstring_nocopy(pkgd, "pkgver", &pkgver)) {
-				rv = EINVAL;
-				break;
-			}
+			if (!xbps_dictionary_get_cstring_nocopy(pkgd, "pkgver", &pkgver))
+				abort();
 			xbps_dbg_printf("found conflicting pkgs in "
 			    "transaction %s <-> %s (matched by %s [pkgdb])\n",
 			    pkgver, repopkgver, cfpkg);
 			buf = xbps_xasprintf("CONFLICT: %s with "
 			   "%s in transaction (matched by %s)",
 			   repopkgver, pkgver, cfpkg);
-			if (!xbps_match_string_in_array(trans_cflicts, buf))
-				xbps_array_add_cstring(trans_cflicts, buf);
-
-			free(buf);
+			if (!buf)
+				return xbps_error_oom();
+			if (!xbps_array_add_cstring_nocopy(trans_cflicts, buf))
+				return xbps_error_oom();
 			continue;
 		}
 	}
-	return rv;
+	return 0;
 }
 
-bool HIDDEN
+int HIDDEN
 xbps_transaction_check_conflicts(struct xbps_handle *xhp, xbps_array_t pkgs)
 {
 	xbps_array_t array;
-	unsigned int i;
+	int r;
 
 	/* find conflicts in transaction */
-	for (i = 0; i < xbps_array_count(pkgs); i++) {
-		pkg_conflicts_trans(xhp, pkgs, xbps_array_get(pkgs, i));
-	}
-	/* find conflicts in pkgdb */
-	if (xbps_pkgdb_foreach_cb_multi(xhp, pkgdb_conflicts_cb, pkgs) != 0) {
-		return false;
+	for (unsigned int i = 0; i < xbps_array_count(pkgs); i++) {
+		r = pkg_conflicts_trans(xhp, pkgs, xbps_array_get(pkgs, i));
+		if (r < 0)
+			return r;
 	}
 
+	/* find conflicts in pkgdb */
+	r = xbps_pkgdb_foreach_cb_multi(xhp, pkgdb_conflicts_cb, pkgs);
+	if (r < 0)
+		return r;
+	else if (r > 0)
+		return -r;
+
 	array = xbps_dictionary_get(xhp->transd, "conflicts");
-	if (xbps_array_count(array) == 0) {
+	if (xbps_array_count(array) == 0)
 		xbps_dictionary_remove(xhp->transd, "conflicts");
-	}
-	return true;
+
+	return 0;
 }

--- a/lib/transaction_check_replaces.c
+++ b/lib/transaction_check_replaces.c
@@ -48,7 +48,7 @@ xbps_transaction_check_replaces(struct xbps_handle *xhp, xbps_array_t pkgs)
 
 	for (unsigned int i = 0; i < xbps_array_count(pkgs); i++) {
 		xbps_array_t replaces;
-		xbps_object_t obj, obj2;
+		xbps_object_t obj;
 		xbps_object_iterator_t iter;
 		xbps_dictionary_t instd, reppkgd;
 		const char *pkgver = NULL;
@@ -69,13 +69,15 @@ xbps_transaction_check_replaces(struct xbps_handle *xhp, xbps_array_t pkgs)
 		iter = xbps_array_iterator(replaces);
 		assert(iter);
 
-		while ((obj2 = xbps_object_iterator_next(iter)) != NULL) {
+		for (unsigned int j = 0; j < xbps_array_count(replaces); j++) {
 			const char *curpkgver = NULL, *pattern = NULL;
 			char curpkgname[XBPS_NAME_SIZE] = {0};
 			bool instd_auto = false, hold = false;
 			xbps_trans_type_t ttype;
 
-			pattern = xbps_string_cstring_nocopy(obj2);
+			if(!xbps_array_get_cstring_nocopy(replaces, j, &pattern))
+				abort();
+
 			/*
 			 * Find the installed package that matches the pattern
 			 * to be replaced.

--- a/lib/transaction_prepare.c
+++ b/lib/transaction_prepare.c
@@ -198,12 +198,12 @@ xbps_transaction_init(struct xbps_handle *xhp)
 		return 0;
 
 	if ((xhp->transd = xbps_dictionary_create()) == NULL)
-		return ENOMEM;
+		return xbps_error_oom();
 
 	if ((array = xbps_array_create()) == NULL) {
 		xbps_object_release(xhp->transd);
 		xhp->transd = NULL;
-		return ENOMEM;
+		return xbps_error_oom();
 	}
 	if (!xbps_dictionary_set(xhp->transd, "packages", array)) {
 		xbps_object_release(xhp->transd);
@@ -215,7 +215,7 @@ xbps_transaction_init(struct xbps_handle *xhp)
 	if ((array = xbps_array_create()) == NULL) {
 		xbps_object_release(xhp->transd);
 		xhp->transd = NULL;
-		return ENOMEM;
+		return xbps_error_oom();
 	}
 	if (!xbps_dictionary_set(xhp->transd, "missing_deps", array)) {
 		xbps_object_release(xhp->transd);
@@ -227,48 +227,48 @@ xbps_transaction_init(struct xbps_handle *xhp)
 	if ((array = xbps_array_create()) == NULL) {
 		xbps_object_release(xhp->transd);
 		xhp->transd = NULL;
-		return ENOMEM;
+		return xbps_error_oom();
 	}
 	if (!xbps_dictionary_set(xhp->transd, "missing_shlibs", array)) {
 		xbps_object_release(xhp->transd);
 		xhp->transd = NULL;
-		return EINVAL;
+		return xbps_error_oom();
 	}
 	xbps_object_release(array);
 
 	if ((array = xbps_array_create()) == NULL) {
 		xbps_object_release(xhp->transd);
 		xhp->transd = NULL;
-		return ENOMEM;
+		return xbps_error_oom();
 	}
 	if (!xbps_dictionary_set(xhp->transd, "conflicts", array)) {
 		xbps_object_release(xhp->transd);
 		xhp->transd = NULL;
-		return EINVAL;
+		return xbps_error_oom();
 	}
 	xbps_object_release(array);
 
 	if ((dict = xbps_dictionary_create()) == NULL) {
 		xbps_object_release(xhp->transd);
 		xhp->transd = NULL;
-		return ENOMEM;
+		return xbps_error_oom();
 	}
 	if (!xbps_dictionary_set(xhp->transd, "obsolete_files", dict)) {
 		xbps_object_release(xhp->transd);
 		xhp->transd = NULL;
-		return EINVAL;
+		return xbps_error_oom();
 	}
 	xbps_object_release(dict);
 
 	if ((dict = xbps_dictionary_create()) == NULL) {
 		xbps_object_release(xhp->transd);
 		xhp->transd = NULL;
-		return ENOMEM;
+		return xbps_error_oom();
 	}
 	if (!xbps_dictionary_set(xhp->transd, "remove_files", dict)) {
 		xbps_object_release(xhp->transd);
 		xhp->transd = NULL;
-		return EINVAL;
+		return xbps_error_oom();
 	}
 	xbps_object_release(dict);
 

--- a/lib/transaction_prepare.c
+++ b/lib/transaction_prepare.c
@@ -283,6 +283,7 @@ xbps_transaction_prepare(struct xbps_handle *xhp)
 	xbps_trans_type_t ttype;
 	unsigned int i, cnt;
 	int rv = 0;
+	int r;
 	bool all_on_hold = true;
 
 	if ((rv = xbps_transaction_init(xhp)) != 0)
@@ -390,10 +391,11 @@ xbps_transaction_prepare(struct xbps_handle *xhp)
 	 * Check for package conflicts.
 	 */
 	xbps_dbg_printf("%s: checking conflicts\n", __func__);
-	if (!xbps_transaction_check_conflicts(xhp, pkgs)) {
+	r = xbps_transaction_check_conflicts(xhp, pkgs);
+	if (r < 0) {
 		xbps_object_release(xhp->transd);
 		xhp->transd = NULL;
-		return EINVAL;
+		return -r;
 	}
 	if (xbps_dictionary_get(xhp->transd, "conflicts")) {
 		return EAGAIN;

--- a/tests/xbps/libxbps/shell/replace_test.sh
+++ b/tests/xbps/libxbps/shell/replace_test.sh
@@ -46,34 +46,33 @@ replace_ntimes_head() {
 replace_ntimes_body() {
 	mkdir some_repo root
 	mkdir -p pkg_A/usr/bin pkg_B/usr/bin pkg_C/usr/bin pkg_D/usr/bin
+
 	cd some_repo
-	xbps-create -A noarch -n A-1.0_1 -s "A pkg" ../pkg_A
-	atf_check_equal $? 0
-	xbps-create -A noarch -n B-1.0_1 -s "B pkg" ../pkg_B
-	atf_check_equal $? 0
-	xbps-create -A noarch -n C-1.0_1 -s "C pkg" ../pkg_C
-	atf_check_equal $? 0
-	xbps-create -A noarch -n D-1.0_1 -s "D pkg" ../pkg_D
-	atf_check_equal $? 0
-	xbps-rindex -d -a $PWD/*.xbps
-	atf_check_equal $? 0
+	atf_check -o ignore -- xbps-create -A noarch -n A-1.0_1 -s "A pkg" ../pkg_A
+	atf_check -o ignore -- xbps-create -A noarch -n B-1.0_1 -s "B pkg" ../pkg_B
+	atf_check -o ignore -- xbps-create -A noarch -n C-1.0_1 -s "C pkg" ../pkg_C
+	atf_check -o ignore -- xbps-create -A noarch -n D-1.0_1 -s "D pkg" ../pkg_D
+	atf_check -o ignore -- xbps-rindex -a $PWD/*.xbps
 	cd ..
-	xbps-install -C xbps.d -r root --repository=$PWD/some_repo -yd A B C D
-	atf_check_equal $? 0
+
+	atf_check -o ignore -e ignore -- \
+		xbps-install -C xbps.d -r root --repository=$PWD/some_repo -yd A B C D
+
 	cd some_repo
-	xbps-create -A noarch -n A-1.1_1 -s "A pkg" ../pkg_A
-	atf_check_equal $? 0
-	xbps-create -A noarch -n B-1.1_1 -s "B pkg" --replaces "A<1.1" ../pkg_B
-	atf_check_equal $? 0
-	xbps-create -A noarch -n C-1.1_1 -s "C pkg" --replaces "A<1.1" ../pkg_C
-	atf_check_equal $? 0
-	xbps-create -A noarch -n D-1.1_1 -s "D pkg" --replaces "A<1.1" ../pkg_D
-	atf_check_equal $? 0
-	xbps-rindex -d -a $PWD/*.xbps
-	atf_check_equal $? 0
+	atf_check -o ignore -- xbps-create -A noarch -n A-1.1_1 -s "A pkg" ../pkg_A
+	atf_check -o ignore -- xbps-create -A noarch -n B-1.1_1 -s "B pkg" --replaces "A<1.1" ../pkg_B
+	atf_check -o ignore -- xbps-create -A noarch -n C-1.1_1 -s "C pkg" --replaces "A<1.1" ../pkg_C
+	atf_check -o ignore -- xbps-create -A noarch -n D-1.1_1 -s "D pkg" --replaces "A<1.1" ../pkg_D
+	atf_check -o ignore -e ignore -- xbps-rindex -a $PWD/*.xbps
 	cd ..
-	result=$(xbps-install -C xbps.d -r root --repository=$PWD/some_repo -yun|wc -l)
-	atf_check_equal $result 4
+
+	atf_check \
+		-o match:"A-1.1_1 update" \
+		-o match:"B-1.1_1 update" \
+		-o match:"C-1.1_1 update" \
+		-o match:"D-1.1_1 update" \
+		-e ignore \
+		-- xbps-install -C xbps.d -r root --repository=$PWD/some_repo -dvyun
 }
 
 atf_test_case self_replace


### PR DESCRIPTION
This mostly reduces temporary allocations since they are easy to identify and fix.