### PR TITLE
fix: fixed segmentation fault caused by `archive_entry_pathname`

### DIFF
--- a/lib/repo.c
+++ b/lib/repo.c
@@ -121,6 +121,7 @@ static int
 repo_read_index(struct xbps_repo *repo, struct archive *ar)
 {
 	struct archive_entry *entry;
+    const char *pathname;
 	char *buf;
 	int r;
 
@@ -129,7 +130,8 @@ repo_read_index(struct xbps_repo *repo, struct archive *ar)
 		return r;
 
 	/* index.plist */
-	if (strcmp(archive_entry_pathname(entry), XBPS_REPODATA_INDEX) != 0) {
+    pathname = archive_entry_pathname(entry);
+	if (strcmp((pathname ? pathname : ""), XBPS_REPODATA_INDEX) != 0) {
 		xbps_error_printf("failed to read repository index: %s: unexpected archive entry\n",
 		    repo->uri);
 		r = -EINVAL;
@@ -175,6 +177,7 @@ static int
 repo_read_meta(struct xbps_repo *repo, struct archive *ar)
 {
 	struct archive_entry *entry;
+    const char *pathname;
 	char *buf;
 	int r;
 
@@ -182,7 +185,8 @@ repo_read_meta(struct xbps_repo *repo, struct archive *ar)
 	if (r < 0)
 		return r;
 
-	if (strcmp(archive_entry_pathname(entry), XBPS_REPODATA_META) != 0) {
+    pathname = archive_entry_pathname(entry);
+	if (strcmp((pathname ? pathname : ""), XBPS_REPODATA_META) != 0) {
 		xbps_error_printf("failed to read repository metadata: %s: unexpected archive entry\n",
 		    repo->uri);
 		r = -EINVAL;
@@ -237,6 +241,7 @@ static int
 repo_read_stage(struct xbps_repo *repo, struct archive *ar)
 {
 	struct archive_entry *entry;
+    const char *pathname;
 	int r;
 
 	r = repo_read_next(repo, ar, &entry);
@@ -249,7 +254,8 @@ repo_read_stage(struct xbps_repo *repo, struct archive *ar)
 		return r;
 	}
 
-	if (strcmp(archive_entry_pathname(entry), XBPS_REPODATA_STAGE) != 0) {
+    pathname = archive_entry_pathname(entry);
+	if (strcmp((pathname ? pathname : ""), XBPS_REPODATA_STAGE) != 0) {
 		xbps_error_printf("failed to read repository stage: %s: unexpected archive entry\n",
 		    repo->uri);
 		r = -EINVAL;


### PR DESCRIPTION
## Description
Found a segmentation fault error after `xbps-install` command has failed to open and read
repository. Built xbps with debug info and found that `archive_entry_pathname` function in
`repo_read_meta` function (`lib/repo.c`) retunes `NULL` and the null pointer passed directly
to `strcmp` function.

xbps version `0.60` used but the latest development branch also has this error.


## Fix
Fixed the segfault by calling `archive_entry_pathname` outside of `strcmp` and checking the
returned value. If it was NULL then replace the pathname with an empty string (`""`).

## Reproduce error
There is no extra steps to reproduce this bug. I didn't know why the main repository failed
like this. I just ran `xbps-install -Syu` and suddenly it blowed up!

## Log
`xbps-install` debug log and segmentation fault at the end:
```
# ~> xbps-install -dSyu

[DEBUG] XBPS: 0.60 API: 20250521 GIT: UNSET
[DEBUG] Processing configuration directory: /etc/xbps.d
[DEBUG] Parsing configuration file: /etc/xbps.d/00-repository-main.conf
[DEBUG] [repo] `https://repo-fi.voidlinux.org/current' stored successfully
[DEBUG] /etc/xbps.d/00-repository-main.conf: added repository https://repo-fi.voidlinux.org/current
[DEBUG] Processing system configuration directory: /usr/share/xbps.d
[DEBUG] Parsing configuration file: /usr/share/xbps.d/10-repository-nonfree.conf
[DEBUG] [repo] `https://repo-default.voidlinux.org/current/nonfree' stored successfully
[DEBUG] /usr/share/xbps.d/10-repository-nonfree.conf: added repository https://repo-default.voidlinux.org/current/nonfree
[DEBUG] Parsing configuration file: /usr/share/xbps.d/void-virtualpkgs.conf
[DEBUG] Parsing configuration file: /usr/share/xbps.d/xbps-arch.conf
[DEBUG] /usr/share/xbps.d/xbps-arch.conf: native architecture set to x86_64
[DEBUG] Parsing configuration file: /usr/share/xbps.d/xbps.conf
[DEBUG] Repository[0]=https://repo-fi.voidlinux.org/current
[DEBUG] Repository[1]=https://repo-default.voidlinux.org/current/nonfree
[*] Updating repository `https://repo-fi.voidlinux.org/current/x86_64-repodata' ...
[DEBUG] st.st_size: 2086314
[DEBUG] st.st_atime: 09 Jul 2025 01:13
[DEBUG] st.st_mtime: 09 Jul 2025 01:13
[DEBUG] url_stat.size: -1
[DEBUG] url_stat.atime: 09 Jul 2025 01:13
[DEBUG] url_stat.mtime: 09 Jul 2025 01:13
[*] Updating repository `https://repo-default.voidlinux.org/current/nonfree/x86_64-repodata' ...
[DEBUG] st.st_size: 15156
[DEBUG] st.st_atime: 07 Jul 2025 19:28
[DEBUG] st.st_mtime: 07 Jul 2025 19:28
[DEBUG] url_stat.size: -1
[DEBUG] url_stat.atime: 07 Jul 2025 19:28
[DEBUG] url_stat.mtime: 07 Jul 2025 19:28
[DEBUG] [rpool] checking `https://repo-fi.voidlinux.org/current' at index 0
ERROR: failed to ready archive entry: index.plist: Truncated tar archive detected while reading data
ERROR: failed to open repository: https://repo-fi.voidlinux.org/current: failed to read index: Unknown error -1
ERROR: failed to read repository: https://repo-fi.voidlinux.org/current: Truncated input file (needed 7989248 bytes, only 0 available)
[1]    12797 segmentation fault  sudo xbps-install -dSyu
```