### PR TITLE
Fixed typo on the permission check message.

### DIFF
--- a/lib/pkgdb.c
+++ b/lib/pkgdb.c
@@ -72,7 +72,7 @@ xbps_pkgdb_lock(struct xbps_handle *xhp)
 
 	if (access(xhp->rootdir, W_OK) == -1 && errno != ENOENT) {
 		return xbps_error_errno(errno,
-		    "failed to check whether the roodir is wriable: "
+		    "failed to check whether the roodir is writable: "
 		    "%s: %s\n",
 		    xhp->rootdir, strerror(errno));
 	}

--- a/lib/pkgdb.c
+++ b/lib/pkgdb.c
@@ -72,7 +72,7 @@ xbps_pkgdb_lock(struct xbps_handle *xhp)
 
 	if (access(xhp->rootdir, W_OK) == -1 && errno != ENOENT) {
 		return xbps_error_errno(errno,
-		    "failed to check whether the roodir is writable: "
+		    "failed to check whether the rootdir is writable: "
 		    "%s: %s\n",
 		    xhp->rootdir, strerror(errno));
 	}


### PR DESCRIPTION
I found this typo when using xbps-install with insufficient permissions, and thought I'd open a PR for fixing it since it's a very minor issue.