### PR TITLE
lib/verifysig.c: fix missing include for PATH_MAX

### DIFF
--- a/lib/verifysig.c
+++ b/lib/verifysig.c
@@ -31,6 +31,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
+#include <limits.h>
 
 #include <openssl/err.h>
 #include <openssl/sha.h>


### PR DESCRIPTION
`verifysig.c` is missing a direct include of `limits.h` for `PATH_MAX`. This is transitively included through `openssl/err.h`, which fails to build in certain configurations.