### PR TITLE
Fix off-by-one error adding ellipsis in list.c

### DIFF
--- a/bin/xbps-query/list.c
+++ b/bin/xbps-query/list.c
@@ -81,9 +81,9 @@ list_pkgs_in_dict(struct xbps_handle *xhp UNUSED,
 		short_desc);
 	/* add ellipsis if the line was truncated */
 	if (len >= lpc->maxcols && lpc->maxcols > 4) {
-		for (unsigned int j = 0; j < 3; j++)
-			lpc->linebuf[lpc->maxcols-j-1] = '.';
-		lpc->linebuf[lpc->maxcols] = '\0';
+		lpc->linebuf[lpc->maxcols - 4] = '.';
+		lpc->linebuf[lpc->maxcols - 3] = '.';
+		lpc->linebuf[lpc->maxcols - 2] = '.';
 	}
 	puts(lpc->linebuf);
 


### PR DESCRIPTION
When running `xbps-query -l` I get:
```
[...]
free(): invalid pointer
Aborted                    xbps-query -l
```
This issue is similar to #650 and #637 and for those issues it was fixed in #645. However, it was only fixed in `search.c`, leaving the same bug in `list.c`. 

The provided patch applies the same change to `list.c`. After this change, `xbps-query -l` runs without error.