### PR TITLE
bin/xbps-checkvers: unhardcode cache file version

### DIFF
--- a/bin/xbps-checkvers/main.c
+++ b/bin/xbps-checkvers/main.c
@@ -791,7 +791,7 @@ main(int argc, char **argv)
 		free(tmp);
 	}
 
-	rcv.cachefile = xbps_xasprintf("%s/.xbps-checkvers-0.58.plist", rcv.distdir);
+	rcv.cachefile = xbps_xasprintf("%s/.xbps-checkvers-%s.plist", rcv.distdir, XBPS_VERSION);
 
 	argc -= optind;
 	argv += optind;


### PR DESCRIPTION
Right now cache file versioning doesn't follow xbps version, make it so.

Fixes: 34a1ab51d07996738529639114ace5a576b3fd62