### PR TITLE
Handle C23 const-preserving libc macros

### DIFF
--- a/bin/xbps-checkvers/main.c
+++ b/bin/xbps-checkvers/main.c
@@ -537,7 +537,8 @@ static int
 rcv_check_version(rcv_t *rcv)
 {
 	const char *repover = NULL;
-	char srcver[BUFSIZ] = { '\0' }, *binpkgname = NULL, *s = NULL;
+	char srcver[BUFSIZ] = { '\0' }, *binpkgname = NULL;
+	const char *s = NULL;
 	const char *pkgname, *version, *revision, *reverts, *repourl;
 	int sz;
 	size_t len;
@@ -661,7 +662,7 @@ template_removed_cb(struct xbps_handle *xhp UNUSED,
 		bool *done UNUSED)
 {
 	char *pkgname;
-	char *last_dash;
+	const char *last_dash;
 	bool dummy_bool = false;
 	rcv_t *rcv = arg;
 

--- a/bin/xbps-create/main.c
+++ b/bin/xbps-create/main.c
@@ -235,7 +235,7 @@ process_one_alternative(const char *altgrname, const char *val)
 {
 	xbps_dictionary_t d;
 	xbps_array_t a;
-	char *altfiles;
+	const char *altfiles;
 	bool alloc = false;
 
 	if ((d = xbps_dictionary_get(pkg_propsd, "alternatives")) == NULL) {

--- a/bin/xbps-uchroot/main.c
+++ b/bin/xbps-uchroot/main.c
@@ -212,7 +212,8 @@ static void
 add_bindmount(const char *bm, bool ro)
 {
 	struct bindmnt *bmnt;
-	char *b, *src, *dest;
+	char *src;
+	const char *b, *dest;
 	size_t len;
 
 	src = strdup(bm);

--- a/lib/conf.c
+++ b/lib/conf.c
@@ -249,7 +249,8 @@ parse_option(char *line, size_t linelen, char **valp, size_t *vallen)
 {
 	size_t len;
 	char *p;
-	struct key needle, *result;
+	struct key needle;
+	const struct key *result;
 
 	p = strpbrk(line, " \t=");
 	if (p == NULL)

--- a/lib/fetch/http.c
+++ b/lib/fetch/http.c
@@ -1339,7 +1339,7 @@ struct index_parser {
 static ssize_t
 parse_index(struct index_parser *parser, const char *buf, size_t len)
 {
-	char *end_attr, p = *buf;
+	const char *end_attr, p = *buf;
 
 	switch (parser->state) {
 	case ST_NONE:
@@ -1463,7 +1463,7 @@ parse_index(struct index_parser *parser, const char *buf, size_t len)
 		end_attr = memchr(buf, '"', len);
 		if (end_attr == NULL)
 			return 0;
-		*end_attr = '\0';
+		*(char *)(uintptr_t)end_attr = '\0';
 		parser->state = ST_TAGA;
 		if (fetch_add_entry(parser->ue, parser->url, buf, 1))
 			return -1;

--- a/lib/package_unpack.c
+++ b/lib/package_unpack.c
@@ -95,7 +95,7 @@ unpack_archive(struct xbps_handle *xhp,
 	struct archive_entry *entry;
 	ssize_t entry_size;
 	const char *entry_pname, *pkgname;
-	char *buf = NULL;
+	const char *buf = NULL;
 	int ar_rv, rv, error, entry_type, flags;
 	bool preserve, update, file_exists, keep_conf_file;
 	bool skip_extract, force, xucd_stats;
@@ -454,14 +454,14 @@ unpack_archive(struct xbps_handle *xhp,
 		if (!xbps_dictionary_externalize_to_file(binpkg_filesd, buf)) {
 			rv = errno;
 			umask(prev_umask);
-			free(buf);
+			free((void *)(uintptr_t)buf);
 			xbps_set_cb_state(xhp, XBPS_STATE_UNPACK_FAIL,
 			    rv, pkgver, "%s: [unpack] failed to externalize pkg "
 			    "pkg metadata files: %s", pkgver, strerror(rv));
 			goto out;
 		}
 		umask(prev_umask);
-		free(buf);
+		free((void *)(uintptr_t)buf);
 	}
 out:
 	/*
@@ -470,7 +470,7 @@ out:
 	if (!xbps_dictionary_count(binpkg_filesd)) {
 		buf = xbps_xasprintf("%s/.%s-files.plist", xhp->metadir, pkgname);
 		unlink(buf);
-		free(buf);
+		free((void *)(uintptr_t)buf);
 	}
 	xbps_object_release(binpkg_filesd);
 


### PR DESCRIPTION
Since [0] some standard library functions (e. g. `memchr`) are const preserving in C23-mode, i. e. return `const char *` instead of `char *` if `const char *` was passed.
gcc-15 uses C23 by default and currently build with gcc-15 & glibc-2.43 fails.

[0] https://sourceware.org/git/?p=glibc.git;a=commit;h=cd748a63ab1a7ae846175c532a3daab341c62690