### PR TITLE
lib/fetch: Add HTTP `Host` header to CONNECT requests

### DIFF
--- a/lib/fetch/http.c
+++ b/lib/fetch/http.c
@@ -753,6 +753,8 @@ http_connect(struct url *URL, struct url *purl, const char *flags, int *cached)
 	if (strcasecmp(URL->scheme, SCHEME_HTTPS) == 0 && purl) {
 		http_cmd(conn, "CONNECT %s:%d HTTP/1.1\r\n",
 		    URL->host, URL->port);
+		http_cmd(conn, "Host: %s:%d\r\n",
+		    URL->host, URL->port);
 
 		send_proxy_headers(conn, purl);
 


### PR DESCRIPTION
According to RFC-9110 [7.2](https://www.rfc-editor.org/info/rfc9110/#section-7.2) the `Host` header must be present in all HTTP/1.1 requests. That seems to include [9.3.6 CONNECT](https://www.rfc-editor.org/info/rfc9110/#section-9.3.6) requests as can be seen in the examples in that later section.

The issue popped up when using void-linux in [WSL](https://github.com/microsoft/WSL) in conjunction with [`px`](https://github.com/genotrance/px) as proxy to handle upstream NTLM proxy authentication (`px` rejects requests without `Host` header). The patch provided solved the issue.

tbh, this PR is kind of a stopgap measure, merging #373 would render it obsolete.