### PR TITLE
lib: remove automatic self replacement

### DIFF
--- a/bin/xbps-pkgdb/check_pkg_unneeded.c
+++ b/bin/xbps-pkgdb/check_pkg_unneeded.c
@@ -25,10 +25,7 @@
 
 #include <sys/param.h>
 
-#include <stdio.h>
 #include <stdbool.h>
-#include <stdlib.h>
-#include <string.h>
 #include <assert.h>
 #include <unistd.h>
 
@@ -43,11 +40,9 @@
  * 	  and remove them if that was true.
  */
 int
-check_pkg_unneeded(struct xbps_handle *xhp UNUSED, const char *pkgname, xbps_dictionary_t pkgd)
+check_pkg_unneeded(struct xbps_handle *xhp UNUSED, const char *pkgname UNUSED, xbps_dictionary_t pkgd)
 {
-	xbps_array_t replaces;
 	const char *repo = NULL;
-	char *buf;
 
 	xbps_dictionary_remove(pkgd, "download");
 	xbps_dictionary_remove(pkgd, "remove-and-update");
@@ -57,16 +52,6 @@ check_pkg_unneeded(struct xbps_handle *xhp UNUSED, const char *pkgname, xbps_dic
 	if (xbps_dictionary_get_cstring_nocopy(pkgd, "repository-origin", &repo)) {
 		xbps_dictionary_set_cstring(pkgd, "repository", repo);
 		xbps_dictionary_remove(pkgd, "repository-origin");
-	}
-	/*
-	 * Remove self replacement when applicable.
-	 */
-	if ((replaces = xbps_dictionary_get(pkgd, "replaces"))) {
-		buf = xbps_xasprintf("%s>=0", pkgname);
-		xbps_remove_string_from_array(replaces, buf);
-		free(buf);
-		if (!xbps_array_count(replaces))
-			xbps_dictionary_remove(pkgd, "replaces");
 	}
 
 	return 0;

--- a/lib/package_register.c
+++ b/lib/package_register.c
@@ -23,7 +23,6 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
@@ -34,7 +33,6 @@
 int HIDDEN
 xbps_register_pkg(struct xbps_handle *xhp, xbps_dictionary_t pkgrd)
 {
-	xbps_array_t replaces;
 	xbps_dictionary_t pkgd;
 	time_t t;
 	struct tm tm, *tmp;
@@ -90,16 +88,6 @@ xbps_register_pkg(struct xbps_handle *xhp, xbps_dictionary_t pkgrd)
 		xbps_dictionary_set_cstring(pkgd, "metafile-sha256", sha256);
 	}
 	free(buf);
-	/*
-	 * Remove self replacement when applicable.
-	 */
-	if ((replaces = xbps_dictionary_get(pkgd, "replaces"))) {
-		buf = xbps_xasprintf("%s>=0", pkgname);
-		xbps_remove_string_from_array(replaces, buf);
-		free(buf);
-		if (!xbps_array_count(replaces))
-			xbps_dictionary_remove(pkgd, "replaces");
-	}
 	/*
 	 * Remove unneeded objs from pkg dictionary.
 	 */

--- a/lib/transaction_store.c
+++ b/lib/transaction_store.c
@@ -23,10 +23,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <errno.h>
 
 #include "xbps_api_impl.h"
 
@@ -35,9 +32,7 @@ xbps_transaction_store(struct xbps_handle *xhp, xbps_array_t pkgs,
 		xbps_dictionary_t pkgrd, bool autoinst)
 {
 	xbps_dictionary_t d, pkgd;
-	xbps_array_t replaces;
 	const char *pkgver, *pkgname, *curpkgver, *repo;
-	char *self_replaced;
 	int rv;
 
 	assert(xhp);
@@ -79,19 +74,6 @@ xbps_transaction_store(struct xbps_handle *xhp, xbps_array_t pkgs,
 	 * Add required objects into package dep's dictionary.
 	 */
 	if (autoinst && !xbps_dictionary_set_bool(pkgd, "automatic-install", true))
-		goto err;
-
-	/*
-	 * Set a replaces to itself, so that virtual packages are always replaced.
-	*/
-	if ((replaces = xbps_dictionary_get(pkgd, "replaces")) == NULL)
-		replaces = xbps_array_create();
-
-	self_replaced = xbps_xasprintf("%s>=0", pkgname);
-	xbps_array_add_cstring(replaces, self_replaced);
-	free(self_replaced);
-
-	if (!xbps_dictionary_set(pkgd, "replaces", replaces))
 		goto err;
 
 	/*

--- a/tests/xbps/libxbps/shell/replace_test.sh
+++ b/tests/xbps/libxbps/shell/replace_test.sh
@@ -87,7 +87,7 @@ self_replace_body() {
 	echo "A-1.0_1" > pkg_A/usr/bin/foo
 	echo "B-1.0_1" > pkg_B/usr/bin/foo
 	cd some_repo
-	atf_check -o ignore -- xbps-create -A noarch -n A-1.0_1 -s "A pkg" ../pkg_A
+	atf_check -o ignore -- xbps-create -A noarch -n A-1.0_1 -s "A pkg" --replaces "A>=0" ../pkg_A
 	atf_check -o ignore -- xbps-create -A noarch -n B-1.0_1 -s "B pkg" --replaces "A>=0" --provides="A-1.0_1" ../pkg_B
 	atf_check -o ignore -- xbps-rindex -a $PWD/*.xbps
 	cd ..


### PR DESCRIPTION
Packages previously automatically added a replacemnet on their own package name so that they can easily replace virtual packages providing that same package name. This causes some unexpected behaviour where util-linux added to hostmakedepends in xbps-src will automatically replace chroot-util-linux and destroy the build chroot doing that.

In general this might have been a bit more useful previously before alternatives allowed to install some virtual packages in parallel.

The test is changed to test wheter explict self replacement works.